### PR TITLE
fix: package.json react-native source path

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/commonjs/index",
   "module": "lib/module/index",
   "types": "lib/typescript/index.d.ts",
-  "react-native": "src/index",
+  "react-native": "lib/module/index",
   "source": "src/index",
   "files": [
     "src",


### PR DESCRIPTION
## Fix package.json's react-native source path 

Was experiencing multiple errors like this while trying to webpack code for react-native:
<img width="975" alt="Screen Shot 2022-08-01 at 12 53 57 PM" src="https://user-images.githubusercontent.com/11483212/182053492-e6bf5779-3049-49f3-ba22-295f29757efa.png">

The `react-native` field in package.json needs to point to the lib folder instead of src folder. Like [react-native-mmkv](https://github.com/mrousavy/react-native-mmkv/blob/master/package.json) for example