### PR TITLE
Fixes #99

### DIFF
--- a/cpp/Cipher/MGLCipherHostObject.cpp
+++ b/cpp/Cipher/MGLCipherHostObject.cpp
@@ -451,7 +451,7 @@ void MGLCipherHostObject::installMethods() {
       "setAuthTag", JSIF([=]) {
         if (count != 1 || !arguments[0].isObject() ||
             !arguments[0].asObject(runtime).isArrayBuffer(runtime)) {
-          jsi::detail::throwJSError(
+          jsi::detail::throwOrDie<jsi::JSError>(
               runtime,
               "cipher.setAuthTag requires an ArrayBuffer tag argument");
           throw jsi::JSError(
@@ -467,7 +467,7 @@ void MGLCipherHostObject::installMethods() {
         auto authTagArrayBuffer =
             arguments[0].asObject(runtime).getArrayBuffer(runtime);
         if (!CheckSizeInt32(runtime, authTagArrayBuffer)) {
-          jsi::detail::throwJSError(
+          jsi::detail::throwOrDie<jsi::JSError>(
               runtime,
               "cipher.setAuthTag requires an ArrayBuffer tag argument");
           throw jsi::JSError(
@@ -502,7 +502,7 @@ void MGLCipherHostObject::installMethods() {
         }
 
         if (!is_valid) {
-          jsi::detail::throwJSError(runtime,
+          jsi::detail::throwOrDie<jsi::JSError>(runtime,
                                     "Invalid authentication tag length");
           throw jsi::JSError(runtime, "Invalid authentication tag length");
         }

--- a/cpp/Cipher/MGLPublicCipherInstaller.h
+++ b/cpp/Cipher/MGLPublicCipherInstaller.h
@@ -57,20 +57,20 @@ FieldDefinition getPublicCipherFieldDefinition(
             runtime, arguments, &offset);
 
         if (!pkey) {
-          jsi::detail::throwJSError(runtime, "Could not generate key");
+          jsi::detail::throwOrDie<jsi::JSError>(runtime, "Could not generate key");
           throw new jsi::JSError(runtime, "Could not generate key");
         }
 
         auto buf = arguments[offset].asObject(runtime).getArrayBuffer(runtime);
         if (!CheckSizeInt32(runtime, buf)) {
-          jsi::detail::throwJSError(runtime, "Data buffer is too long");
+          jsi::detail::throwOrDie<jsi::JSError>(runtime, "Data buffer is too long");
           throw new jsi::JSError(runtime, "Data buffer is too long");
         }
 
         uint32_t padding =
             static_cast<uint32_t>(arguments[offset + 1].getNumber());
         if (!padding) {
-          jsi::detail::throwJSError(runtime, "Invalid padding");
+          jsi::detail::throwOrDie<jsi::JSError>(runtime, "Invalid padding");
           throw new jsi::JSError(runtime, "Invalid padding");
         }
 
@@ -81,7 +81,7 @@ FieldDefinition getPublicCipherFieldDefinition(
 
           digest = EVP_get_digestbyname(oaep_str.c_str());
           if (digest == nullptr) {
-            jsi::detail::throwJSError(runtime, "Invalid digest (oaep_str)");
+            jsi::detail::throwOrDie<jsi::JSError>(runtime, "Invalid digest (oaep_str)");
             throw new jsi::JSError(runtime, "Invalid digest (oaep_str)");
           }
         }
@@ -90,7 +90,7 @@ FieldDefinition getPublicCipherFieldDefinition(
           auto oaep_label_buffer =
               arguments[offset + 3].getObject(runtime).getArrayBuffer(runtime);
           if (!CheckSizeInt32(runtime, oaep_label_buffer)) {
-            jsi::detail::throwJSError(runtime, "oaep_label buffer is too long");
+            jsi::detail::throwOrDie<jsi::JSError>(runtime, "oaep_label buffer is too long");
             throw new jsi::JSError(runtime, "oaep_label buffer is too long");
           }
         }
@@ -101,7 +101,7 @@ FieldDefinition getPublicCipherFieldDefinition(
                 runtime, pkey, padding, digest, arguments[offset + 3], buf);
 
         if (!out.has_value()) {
-          jsi::detail::throwJSError(runtime, "Failed to decrypt");
+          jsi::detail::throwOrDie<jsi::JSError>(runtime, "Failed to decrypt");
           throw new jsi::JSError(runtime, "Failed to decrypt");
         }
 

--- a/cpp/Cipher/MGLRsa.cpp
+++ b/cpp/Cipher/MGLRsa.cpp
@@ -108,7 +108,7 @@ RsaKeyPairGenConfig prepareRsaKeyGenConfig(jsi::Runtime& runtime,
           arguments[offset].asString(runtime).utf8(runtime).c_str());
 
       if (config.md == nullptr) {
-        jsi::detail::throwJSError(runtime, "invalid digest");
+        jsi::detail::throwOrDie<jsi::JSError>(runtime, "invalid digest");
         throw new jsi::JSError(runtime, "invalid digest");
       }
     }
@@ -119,7 +119,7 @@ RsaKeyPairGenConfig prepareRsaKeyGenConfig(jsi::Runtime& runtime,
           arguments[offset + 1].asString(runtime).utf8(runtime).c_str());
 
       if (config.mgf1_md == nullptr) {
-        jsi::detail::throwJSError(runtime, "invalid digest");
+        jsi::detail::throwOrDie<jsi::JSError>(runtime, "invalid digest");
         throw new jsi::JSError(runtime, "invalid digest");
       }
     }
@@ -129,7 +129,7 @@ RsaKeyPairGenConfig prepareRsaKeyGenConfig(jsi::Runtime& runtime,
       config.saltlen = static_cast<int>(arguments[offset + 2].asNumber());
 
       if (config.saltlen < 0) {
-        jsi::detail::throwJSError(runtime, "salt length is out of range");
+        jsi::detail::throwOrDie<jsi::JSError>(runtime, "salt length is out of range");
         throw new jsi::JSError(runtime, "salt length is out of range");
       }
     }
@@ -157,14 +157,14 @@ std::pair<StringOrBuffer, StringOrBuffer> generateRSAKeyPair(
   EVPKeyCtxPointer ctx = setup(config);
 
   if (!ctx) {
-    jsi::detail::throwJSError(runtime, "Error on key generation job");
+    jsi::detail::throwOrDie<jsi::JSError>(runtime, "Error on key generation job");
     throw new jsi::JSError(runtime, "Error on key generation job");
   }
 
   // Generate the key
   EVP_PKEY* pkey = nullptr;
   if (!EVP_PKEY_keygen(ctx.get(), &pkey)) {
-    jsi::detail::throwJSError(runtime, "Error generating key");
+    jsi::detail::throwOrDie<jsi::JSError>(runtime, "Error generating key");
     throw new jsi::JSError(runtime, "Error generating key");
   }
 
@@ -178,7 +178,7 @@ std::pair<StringOrBuffer, StringOrBuffer> generateRSAKeyPair(
                                           config->private_key_encoding);
 
   if (!publicBuffer.has_value() || !privateBuffer.has_value()) {
-    jsi::detail::throwJSError(runtime,
+    jsi::detail::throwOrDie<jsi::JSError>(runtime,
                               "Failed to encode public and/or private key");
   }
 

--- a/cpp/MGLKeys.cpp
+++ b/cpp/MGLKeys.cpp
@@ -348,7 +348,7 @@ std::optional<StringOrBuffer> WritePrivateKey(
   }
 
   if (err) {
-    jsi::detail::throwJSError(runtime, "Failed to encode private key");
+    jsi::detail::throwOrDie<jsi::JSError>(runtime, "Failed to encode private key");
     return {};
   }
 
@@ -389,7 +389,7 @@ std::optional<StringOrBuffer> WritePublicKey(
   //  CHECK(bio);
 
   if (!WritePublicKeyInner(pkey, bio, config)) {
-    jsi::detail::throwJSError(runtime, "Failed to encode public key");
+    jsi::detail::throwOrDie<jsi::JSError>(runtime, "Failed to encode public key");
     return std::nullopt;
   }
 
@@ -648,7 +648,7 @@ ManagedEVPPKey::GetPrivateKeyEncodingFromJs(jsi::Runtime& runtime,
         auto cipher_name = arguments[*offset].getString(runtime).utf8(runtime);
         result.cipher_ = EVP_get_cipherbyname(cipher_name.c_str());
         if (result.cipher_ == nullptr) {
-          jsi::detail::throwJSError(runtime, "Unknown cipher");
+          jsi::detail::throwOrDie<jsi::JSError>(runtime, "Unknown cipher");
           return NonCopyableMaybe<PrivateKeyEncodingConfig>();
         }
         needs_passphrase = true;
@@ -666,7 +666,7 @@ ManagedEVPPKey::GetPrivateKeyEncodingFromJs(jsi::Runtime& runtime,
       jsi::ArrayBuffer passphrase =
           arguments[*offset].asObject(runtime).getArrayBuffer(runtime);
       if (!CheckSizeInt32(runtime, passphrase)) {
-        jsi::detail::throwJSError(runtime, "passphrase is too long");
+        jsi::detail::throwOrDie<jsi::JSError>(runtime, "passphrase is too long");
       }
 
       result.passphrase_ = NonCopyableMaybe<ByteSource>(
@@ -674,7 +674,7 @@ ManagedEVPPKey::GetPrivateKeyEncodingFromJs(jsi::Runtime& runtime,
     } else {
       if (needs_passphrase &&
           (arguments[*offset].isNull() || arguments[*offset].isUndefined())) {
-        jsi::detail::throwJSError(
+        jsi::detail::throwOrDie<jsi::JSError>(
             runtime, "passphrase is null or unfedined but it is required");
       }
     }
@@ -728,7 +728,7 @@ ManagedEVPPKey ManagedEVPPKey::GetPublicOrPrivateKeyFromJs(
         args[(*offset)++].asObject(runtime).getArrayBuffer(runtime);
 
     if (!CheckSizeInt32(runtime, dataArrayBuffer)) {
-      jsi::detail::throwJSError(runtime, "data is too big");
+      jsi::detail::throwOrDie<jsi::JSError>(runtime, "data is too big");
     }
 
     NonCopyableMaybe<PrivateKeyEncodingConfig> config_ =
@@ -766,7 +766,7 @@ ManagedEVPPKey ManagedEVPPKey::GetPublicOrPrivateKeyFromJs(
           is_public = false;
           break;
         default:
-          jsi::detail::throwJSError(runtime, "Invalid key encoding type");
+          jsi::detail::throwOrDie<jsi::JSError>(runtime, "Invalid key encoding type");
           throw new jsi::JSError(runtime, "Invalid key encoding type");
       }
 
@@ -784,7 +784,7 @@ ManagedEVPPKey ManagedEVPPKey::GetPublicOrPrivateKeyFromJs(
     return ManagedEVPPKey::GetParsedKey(runtime, std::move(pkey), ret,
                                         "Failed to read asymmetric key");
   } else {
-    jsi::detail::throwJSError(runtime,
+    jsi::detail::throwOrDie<jsi::JSError>(runtime,
                               "publicEncrypt api only supports ArrayBuffer keys"
                               "for now");
     throw new jsi::JSError(
@@ -808,11 +808,11 @@ ManagedEVPPKey ManagedEVPPKey::GetParsedKey(jsi::Runtime& runtime,
       //       CHECK(pkey);
       break;
     case ParseKeyResult::kParseKeyNeedPassphrase:
-      jsi::detail::throwJSError(runtime,
+      jsi::detail::throwOrDie<jsi::JSError>(runtime,
                                 "Passphrase required for encrypted key");
       break;
     default:
-      jsi::detail::throwJSError(runtime, default_msg);
+      jsi::detail::throwOrDie<jsi::JSError>(runtime, default_msg);
       throw new jsi::JSError(runtime, default_msg);
   }
 

--- a/cpp/Sig/MGLSignHostObjects.cpp
+++ b/cpp/Sig/MGLSignHostObjects.cpp
@@ -350,7 +350,7 @@ void SignBase::InstallMethods(mode mode) {
   this->fields.push_back(buildPair(
       "init", JSIF([=]) {
         if (count != 1 || !arguments[0].isString()) {
-          jsi::detail::throwJSError(runtime, "init requires algorithm param");
+          jsi::detail::throwOrDie<jsi::JSError>(runtime, "init requires algorithm param");
           return {};
         }
 
@@ -378,19 +378,19 @@ void SignBase::InstallMethods(mode mode) {
   this->fields.push_back(buildPair(
       "update", JSIF([=]) {
         if (count != 1) {
-          jsi::detail::throwJSError(runtime, "update requires 2 arguments");
+          jsi::detail::throwOrDie<jsi::JSError>(runtime, "update requires 2 arguments");
         }
 
         if (!arguments[0].isObject() ||
             !arguments[0].asObject(runtime).isArrayBuffer(runtime)) {
-          jsi::detail::throwJSError(
+          jsi::detail::throwOrDie<jsi::JSError>(
               runtime, "First argument (data) needs to be an array buffer");
         }
 
         auto data = arguments[0].asObject(runtime).getArrayBuffer(runtime);
 
         if (!CheckSizeInt32(runtime, data)) {
-          jsi::detail::throwJSError(runtime, "data is too large");
+          jsi::detail::throwOrDie<jsi::JSError>(runtime, "data is too large");
         }
 
         if (mdctx_ == nullptr) return (int)kSignNotInitialised;
@@ -433,7 +433,7 @@ void SignBase::InstallMethods(mode mode) {
               this->SignFinal(runtime, key, padding, salt_len, dsa_sig_enc);
 
           if (ret.error != kSignOk) {
-            jsi::detail::throwJSError(runtime, "Error signing");
+            jsi::detail::throwOrDie<jsi::JSError>(runtime, "Error signing");
             throw new jsi::JSError(runtime, "Error signing");
           }
 
@@ -455,7 +455,7 @@ void SignBase::InstallMethods(mode mode) {
           jsi::ArrayBuffer hbuf =
               arguments[offset].asObject(runtime).getArrayBuffer(runtime);
           if (!CheckSizeInt32(runtime, hbuf)) {
-            jsi::detail::throwJSError(runtime, "buffer is too big");
+            jsi::detail::throwOrDie<jsi::JSError>(runtime, "buffer is too big");
             throw jsi::JSError(runtime, "buffer is too big");
           }
 
@@ -482,7 +482,7 @@ void SignBase::InstallMethods(mode mode) {
             signature = ConvertSignatureToDER(
                 pkey, ArrayBufferToByteSource(runtime, hbuf));
             if (signature.data() == nullptr) {
-              jsi::detail::throwJSError(runtime, "kSignMalformedSignature");
+              jsi::detail::throwOrDie<jsi::JSError>(runtime, "kSignMalformedSignature");
             }
             //          return crypto::CheckThrow(env,
             //          Error::kSignMalformedSignature);
@@ -492,7 +492,7 @@ void SignBase::InstallMethods(mode mode) {
           Error err = this->VerifyFinal(pkey, signature, padding, salt_len,
                                         &verify_result);
           if (err != kSignOk) {
-            jsi::detail::throwJSError(runtime, "Error on verify");
+            jsi::detail::throwOrDie<jsi::JSError>(runtime, "Error on verify");
           }
 
           return verify_result;


### PR DESCRIPTION
Replaces outdated instances of `throwJSError` with `throwOrDie<jsi::JSError>`.
Working: RN 7.0.1
Not tested: RN below 7.0.1