### PR TITLE
Make RNQC compatible with Expo 48 and React-Native 0.71

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -1,26 +1,23 @@
+project(react-native-quick-crypto)
 cmake_minimum_required(VERSION 3.9.0)
 
 set (PACKAGE_NAME "react-native-quick-crypto")
 set (BUILD_DIR ${CMAKE_SOURCE_DIR}/build)
-file (GLOB LIBFBJNI_INCLUDES "${BUILD_DIR}/fbjni-*-headers.jar/")
-file (GLOB LIBRN_SO "${BUILD_DIR}/react-native-0*/jni/${ANDROID_ABI}")
 set (CMAKE_CXX_STANDARD 17)
 # TODO(osp) remove before release
 #set (CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -g")
 #set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g")
+find_package(fbjni REQUIRED CONFIG)
+find_package(ReactAndroid REQUIRED CONFIG)
 
 include_directories(
         ../cpp
-        "${NODE_MODULES_DIR}/react-native/React"
-        "${NODE_MODULES_DIR}/react-native/React/Base"
-        "${NODE_MODULES_DIR}/react-native/ReactAndroid/src/main/jni"
-        "${NODE_MODULES_DIR}/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/jni"
+        "${NODE_MODULES_DIR}/react-native/ReactAndroid/src/main/jni/react/turbomodule"
         "${NODE_MODULES_DIR}/react-native/ReactCommon"
         "${NODE_MODULES_DIR}/react-native/ReactCommon/callinvoker"
         "${NODE_MODULES_DIR}/react-native/ReactCommon/jsi"
         "${NODE_MODULES_DIR}/react-native/ReactCommon/turbomodule/core"
         "${NODE_MODULES_DIR}/react-native/ReactCommon/react/nativemodule/core"
-        "${LIBFBJNI_INCLUDES}"
 )
 
 if(${REACT_NATIVE_VERSION} LESS 66)
@@ -30,7 +27,8 @@ if(${REACT_NATIVE_VERSION} LESS 66)
         )
 endif()
 
-add_library(reactnativequickcrypto  # <-- Library name
+add_library(
+        ${PACKAGE_NAME}
         SHARED
         "src/main/cpp/cpp-adapter.cpp"
         "../cpp/MGLQuickCryptoHostObject.cpp"
@@ -60,7 +58,8 @@ add_library(reactnativequickcrypto  # <-- Library name
 )
 
 set_target_properties(
-        reactnativequickcrypto PROPERTIES
+        ${PACKAGE_NAME}
+        PROPERTIES
         CXX_STANDARD 17
         CXX_EXTENSIONS OFF
         POSITION_INDEPENDENT_CODE ON
@@ -72,54 +71,17 @@ find_library(
         log-lib
         log
 )
-find_library(
-        REACT_NATIVE_JNI_LIB
-        reactnativejni
-        PATHS ${LIBRN_DIR}
-        NO_CMAKE_FIND_ROOT_PATH
-)
-find_library(
-        FBJNI_LIB
-        fbjni
-        PATHS ${LIBRN_SO}
-        NO_CMAKE_FIND_ROOT_PATH
-)
-find_library(
-        TURBOMODULES_LIB
-        turbomodulejsijni
-        PATHS ${LIBRN_DIR}
-        NO_CMAKE_FIND_ROOT_PATH
-)
-find_library(
-        REACT_LIB
-        react_nativemodule_core
-        PATHS ${LIBRN_DIR}
-        NO_CMAKE_FIND_ROOT_PATH
-)
-
-if(${REACT_NATIVE_VERSION} LESS 66)
-        # JSI lib didn't exist on RN 0.65 and before. Simply omit it.
-        set (JSI_LIB "")
-else()
-        # RN 0.66 distributes libjsi.so, can be used instead of compiling jsi.cpp manually.
-        find_library(
-                JSI_LIB
-                jsi
-                PATHS ${LIBRN_DIR}
-                NO_CMAKE_FIND_ROOT_PATH
-        )
-endif()
 
 find_package(openssl REQUIRED CONFIG)
 
 target_link_libraries(
-        reactnativequickcrypto
-        ${TURBOMODULES_LIB}
-        ${FBJNI_LIB}
+        ${PACKAGE_NAME}
+        ReactAndroid::turbomodulejsijni
+        fbjni::fbjni
         ${log-lib}
-        ${JSI_LIB}
-        ${REACT_NATIVE_JNI_LIB}
-        ${REACT_LIB}
+        ReactAndroid::jsi
+        ReactAndroid::reactnativejni
+        ReactAndroid::react_nativemodule_core
         android
         openssl::crypto
 )

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -118,7 +118,16 @@ android {
   }
 
   packagingOptions {
-    excludes = ["**/libc++_shared.so", "**/libfbjni.so", "**/libreactnativejni.so", "**/libjsi.so", "**/MANIFEST.MF", ""]
+    excludes = [
+      "**/libc++_shared.so",
+      "**/libfbjni.so",
+      "**/libreactnativejni.so",
+      "**/libjsi.so",
+      "**/libreact_nativemodule_core.so",
+      "**/libturbomodulejsijni.so",
+      "**/MANIFEST.MF",
+      ""
+    ]
     doNotStrip '**/*.so'
   }
 
@@ -168,13 +177,7 @@ repositories {
 dependencies {
   // https://mvnrepository.com/artifact/com.android.ndk.thirdparty/openssl
   implementation 'com.android.ndk.thirdparty:openssl:1.1.1l-beta-1'
-  // noinspection GradleDynamicVersion
-  implementation 'com.facebook.react:react-native:+'
-
-  //noinspection GradleDynamicVersion
-  extractHeaders("com.facebook.fbjni:fbjni:+:headers")
-  //noinspection GradleDynamicVersion
-  extractJNI("com.facebook.fbjni:fbjni:+")
+  implementation "com.facebook.react:react-android:"
 
   if (!sourceBuild) {
     def buildType = "debug"
@@ -183,12 +186,6 @@ dependencies {
         buildType = "release"
       }
     })
-    def rnAarMatcher = "**/react-native/**/*${buildType}.aar"
-    if (REACT_NATIVE_VERSION < 69) {
-      rnAarMatcher = "**/**/*.aar"
-    }
-    def rnAAR = fileTree("${defaultDir.toString()}").matching({ it.include rnAarMatcher }).singleFile
-    extractJNI(files(rnAAR))
   }
 }
 
@@ -375,8 +372,6 @@ afterEvaluate {
     nativeBuildDependsOn(":ReactAndroid:packageReactNdkDebugLibsForBuck", "Debug")
     nativeBuildDependsOn(":ReactAndroid:packageReactNdkReleaseLibsForBuck", "Rel")
   } else {
-    nativeBuildDependsOn(extractAARHeaders, null)
     nativeBuildDependsOn(extractJNIFiles, null)
-    nativeBuildDependsOn(prepareThirdPartyNdkHeaders, null)
   }
 }

--- a/android/src/main/java/com/margelo/quickcrypto/QuickCryptoModule.java
+++ b/android/src/main/java/com/margelo/quickcrypto/QuickCryptoModule.java
@@ -39,7 +39,7 @@ public class QuickCryptoModule extends ReactContextBaseJavaModule {
         return false;
       }
       Log.i(NAME, "Loading C++ library...");
-      System.loadLibrary("reactnativequickcrypto");
+      System.loadLibrary("react-native-quick-crypto");
 
       JavaScriptContextHolder jsContext = getReactApplicationContext().getJavaScriptContextHolder();
       CallInvokerHolderImpl jsCallInvokerHolder = (CallInvokerHolderImpl) getReactApplicationContext()

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -1,7 +1,7 @@
 require_relative '../node_modules/react-native/scripts/react_native_pods'
 require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
 
-platform :ios, '11.0'
+platform :ios, '12.4'
 
 target 'QuickCryptoExample' do
   config = use_native_modules!

--- a/react-native-quick-crypto.podspec
+++ b/react-native-quick-crypto.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license      = package["license"]
   s.authors      = package["authors"]
 
-  s.platforms    = { :ios => "11.0", :tvos => "12.0", :osx => "10.14" }
+  s.platforms    = { :ios => "12.4", :tvos => "12.0", :osx => "10.14" }
   s.source       = { :git => "https://github.com/mrousavy/react-native-quick-crypto.git", :tag => "#{s.version}" }
 
   # All source files that should be publicly visible


### PR DESCRIPTION
The build scripts associated with RNQC prevent building due to the react-native package /android folder going away and restrictions on build information like AAR. 

Change that caused this issue: 
The issue with the maintained one react-native-quick-crypto has to deal with this https://github.com/react-native-community/discussions-and-proposals/pull/508 change

Patch for this PR copied from issue: https://github.com/margelo/react-native-quick-crypto/issues/143

Don't upgrade gradle, I faced failures when latest expo rebuild used Gradle 7.4. Tested and worked with gradle -classpath('com.android.tools.build:gradle:7.3.1'). Use this patch at your own discretion; solely meant to unblock people. Lots of messages, but the build works locally for my app. 