### PR TITLE
fix(deps): moved react-native-quick-base64 into peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
   },
   "peerDependencies": {
     "react": "*",
-    "react-native": "*"
+    "react-native": "*",
+    "react-native-quick-base64": "^2.0.2"
   },
   "release-it": {
     "git": {
@@ -161,7 +162,6 @@
     "@craftzdog/react-native-buffer": "^6.0.4",
     "@types/node": "^17.0.31",
     "events": "^3.3.0",
-    "react-native-quick-base64": "^2.0.2",
     "stream-browserify": "^3.0.0",
     "string_decoder": "^1.3.0",
     "crypto-browserify": "^3.12.0"


### PR DESCRIPTION
`react-native-quick-base64` should be `peer-dependency since we ask the user to install it manually for auto-link to work. 