### PR TITLE
Fix incorrect validateString check.

### DIFF
--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -151,7 +151,7 @@ export function ab2str(buf: ArrayBuffer, encoding: string = 'hex') {
 
 export function validateString(str: any, name?: string): str is string {
   const isString = typeof str === 'string';
-  if (isString) {
+  if (!isString) {
     throw new Error(`${name} is not a string`);
   }
   return isString;


### PR DESCRIPTION
It seems like this should just be inverted, unless I'm missing something? I'm unable to pass any valid values to options.hash  or options.hashAlgorithm for generateSigningKeyPair, etc.