### PR TITLE
Update react-native-quick-crypto.podspec - Expo Fix

### DIFF
--- a/react-native-quick-crypto.podspec
+++ b/react-native-quick-crypto.podspec
@@ -41,4 +41,5 @@ Pod::Spec.new do |s|
   s.dependency "React-Core"
   s.dependency "React"
   s.dependency "React-callinvoker"
+  s.dependency "ReactCommon"
 end


### PR DESCRIPTION
Update react-native-quick-crypto.podspec, as per #191 and patch by @dhalul in #187