### PR TITLE
fix: openssl3 compilation failure

### DIFF
--- a/cpp/Cipher/MGLCipherHostObject.cpp
+++ b/cpp/Cipher/MGLCipherHostObject.cpp
@@ -577,7 +577,7 @@ bool MGLCipherHostObject::InitAuthenticated(const char *cipher_type, int iv_len,
     // TODO(tniessen) Support CCM decryption in FIPS mode
 
 #if OPENSSL_VERSION_MAJOR >= 3
-    if (mode == EVP_CIPH_CCM_MODE && kind_ == kDecipher &&
+    if (mode == EVP_CIPH_CCM_MODE && !isCipher_ &&
         EVP_default_properties_is_fips_enabled(nullptr)) {
 #else
     if (mode == EVP_CIPH_CCM_MODE && !isCipher_ && FIPS_mode()) {

--- a/cpp/Cipher/MGLCipherHostObject.h
+++ b/cpp/Cipher/MGLCipherHostObject.h
@@ -23,7 +23,6 @@ namespace jsi = facebook::jsi;
 
 class MGLCipherHostObject : public MGLSmartHostObject {
  protected:
-  enum CipherKind { kCipher, kDecipher };
   enum UpdateResult { kSuccess, kErrorMessageSize, kErrorState };
   enum AuthTagState { kAuthTagUnknown, kAuthTagKnown, kAuthTagPassedToOpenSSL };
 

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -1,7 +1,9 @@
 require_relative '../node_modules/react-native/scripts/react_native_pods'
 require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
 
-platform :ios, min_ios_version_supported
+# platform :ios, min_ios_version_supported
+# OPENSSL3: To test openssl 3, uncomment this line
+platform :ios, '15.0'
 prepare_react_native_project!
 
 # If you are using a `react-native-flipper` your iOS build will fail when `NO_FLIPPER=1` is set.
@@ -14,6 +16,8 @@ prepare_react_native_project!
 #     ...(process.env.NO_FLIPPER ? { 'react-native-flipper': { platforms: { ios: null } } } : {}),
 # ```
 flipper_config = ENV['NO_FLIPPER'] == "1" ? FlipperConfiguration.disabled : FlipperConfiguration.enabled
+# OPENSSL3: To test openssl 3, uncomment this line
+flipper_config = FlipperConfiguration.disabled
 
 linkage = ENV['USE_FRAMEWORKS']
 if linkage != nil
@@ -49,6 +53,9 @@ target 'QuickCryptoExample' do
     inherit! :complete
     # Pods for testing
   end
+
+  # OPENSSL3: To test openssl 3, uncomment this line
+  pod 'OpenSSL-Universal', '~> 3.1'
 
   post_install do |installer|
     react_native_post_install(


### PR DESCRIPTION
hi there i am new to the repo and not entirely understand the context and how it reach to current state, please look carefully before merge.

It seems when openssl >= 3 is used the code is trying to access an enum variable `kind_` which doesn't exist and caused compilation failure, the enum `CipherType` has not been used anywhere else. 

There are some test failures but it seems they were there before, and they only occurs if you run createCipher test upfront:



related issue: https://github.com/margelo/react-native-quick-crypto/issues/189
