### PR TITLE
types: improve cipher types

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@types/chai": "^4.3.4",
     "@types/jest": "^29.5.11",
     "@types/mocha": "^10.0.1",
-    "@types/node": "^17.0.31",
+    "@types/node": "^20.12.7",
     "@types/react": "^18.0.33",
     "@types/readable-stream": "^4.0.11",
     "eslint": "^8.4.1",

--- a/src/Cipher.ts
+++ b/src/Cipher.ts
@@ -15,19 +15,21 @@ import {
   validateInt32,
 } from './Utils';
 import { type InternalCipher, RSAKeyVariant } from './NativeQuickCrypto/Cipher';
-// TODO(osp) re-enable type specific constructors
-// They are nice to have but not absolutely necessary
-// import type {
-//   CipherCCMOptions,
-//   CipherCCMTypes,
-//   CipherGCMTypes,
-//   CipherGCMOptions,
-//   // CipherKey,
-//   // KeyObject,
-//   // TODO(Szymon) This types seem to be missing? Where did you get this definitions from?
-//   // CipherOCBTypes,
-//   // CipherOCBOptions,
-// } from 'crypto'; // Node crypto typings
+import type {
+  CipherCCMOptions,
+  CipherCCMTypes,
+  CipherGCMTypes,
+  CipherGCMOptions,
+  CipherOCBOptions,
+  CipherOCBTypes,
+  DecipherGCM,
+  DecipherOCB,
+  DecipherCCM,
+  CipherKey,
+  CipherCCM,
+  CipherOCB,
+  CipherGCM,
+} from 'crypto'; // @types/node
 import { StringDecoder } from 'string_decoder';
 import { Buffer } from '@craftzdog/react-native-buffer';
 import { Buffer as SBuffer } from 'safe-buffer';
@@ -106,7 +108,7 @@ class CipherCommon extends Stream.Transform {
 
   constructor(
     cipherType: string,
-    cipherKey: BinaryLike,
+    cipherKey: CipherKey,
     isCipher: boolean,
     options: Record<string, any> = {},
     iv?: BinaryLike | null
@@ -217,7 +219,7 @@ class CipherCommon extends Stream.Transform {
 class Cipher extends CipherCommon {
   constructor(
     cipherType: string,
-    cipherKey: BinaryLike,
+    cipherKey: CipherKey,
     options: Record<string, any> = {},
     iv?: BinaryLike | null
   ) {
@@ -231,7 +233,7 @@ class Cipher extends CipherCommon {
 class Decipher extends CipherCommon {
   constructor(
     cipherType: string,
-    cipherKey: BinaryLike,
+    cipherKey: CipherKey,
     options: Record<string, any> = {},
     iv?: BinaryLike | null
   ) {
@@ -243,66 +245,101 @@ class Decipher extends CipherCommon {
   }
 }
 
-// TODO(osp) This definitions cause typescript errors when using the API
-// export function createDecipher(
-//   algorithm: CipherCCMTypes,
-//   password: BinaryLike,
-//   options: CipherCCMOptions
-// ): Decipher;
-// export function createDecipher(
-//   algorithm: CipherGCMTypes,
-//   password: BinaryLike,
-//   options?: CipherGCMOptions
-// ): Decipher;
+export function createDecipher(
+  algorithm: CipherCCMTypes,
+  password: CipherKey,
+  options: CipherCCMOptions
+): DecipherCCM;
+export function createDecipher(
+  algorithm: CipherGCMTypes,
+  password: CipherKey,
+  options?: CipherGCMOptions
+): DecipherGCM;
 export function createDecipher(
   algorithm: string,
-  password: BinaryLike,
-  options?: Record<string, unknown> | Stream.TransformOptions
-): Decipher {
+  password: CipherKey,
+  options?: CipherCCMOptions | CipherGCMOptions | Stream.TransformOptions
+): DecipherCCM | DecipherGCM | Decipher {
   return new Decipher(algorithm, password, options);
 }
 
-// function createDecipheriv(algorithm: CipherCCMTypes, key: CipherKey, iv: BinaryLike, options: CipherCCMOptions): DecipherCCM;
-// function createDecipheriv(algorithm: CipherOCBTypes, key: CipherKey, iv: BinaryLike, options: CipherOCBOptions): DecipherOCB;
-// function createDecipheriv(algorithm: CipherGCMTypes, key: CipherKey, iv: BinaryLike, options?: CipherGCMOptions): DecipherGCM;
+export function createDecipheriv(
+  algorithm: CipherCCMTypes,
+  key: CipherKey,
+  iv: BinaryLike,
+  options: CipherCCMOptions
+): DecipherCCM;
+export function createDecipheriv(
+  algorithm: CipherOCBTypes,
+  key: CipherKey,
+  iv: BinaryLike,
+  options: CipherOCBOptions
+): DecipherOCB;
+export function createDecipheriv(
+  algorithm: CipherGCMTypes,
+  key: CipherKey,
+  iv: BinaryLike,
+  options?: CipherGCMOptions
+): DecipherGCM;
 export function createDecipheriv(
   algorithm: string,
-  key: BinaryLike,
+  key: CipherKey,
   iv: BinaryLike | null,
-  options?: Record<string, unknown> | Stream.TransformOptions
-): Decipher {
+  options?:
+    | CipherCCMOptions
+    | CipherOCBOptions
+    | CipherGCMOptions
+    | Stream.TransformOptions
+): DecipherCCM | DecipherOCB | DecipherGCM | Decipher {
   return new Decipher(algorithm, key, options, iv);
 }
 
-// TODO(osp) This definitions cause typescript errors when using the API
-// commenting them out for now
-// export function createCipher(
-//   algorithm: CipherCCMTypes,
-//   password: BinaryLike,
-//   options: CipherCCMOptions
-// ): Cipher;
-// export function createCipher(
-//   algorithm: CipherGCMTypes,
-//   password: BinaryLike,
-//   options?: CipherGCMOptions
-// ): Cipher;
+export function createCipher(
+  algorithm: CipherCCMTypes,
+  password: CipherKey,
+  options: CipherCCMOptions
+): CipherCCM;
+export function createCipher(
+  algorithm: CipherGCMTypes,
+  password: CipherKey,
+  options?: CipherGCMOptions
+): CipherGCM;
 export function createCipher(
   algorithm: string,
-  password: BinaryLike,
-  options?: Record<string, unknown> | Stream.TransformOptions
-): Cipher {
+  password: CipherKey,
+  options?: CipherGCMOptions | CipherCCMOptions | Stream.TransformOptions
+): CipherCCM | CipherGCM | Cipher {
   return new Cipher(algorithm, password, options);
 }
 
-// export function createCipheriv(algorithm: CipherCCMTypes, key: CipherKey, iv: BinaryLike, options: CipherCCMOptions): CipherCCM;
-// export function createCipheriv(algorithm: CipherOCBTypes, key: CipherKey, iv: BinaryLike, options: CipherOCBOptions): CipherOCB;
-// export function createCipheriv(algorithm: CipherGCMTypes, key: CipherKey, iv: BinaryLike, options?: CipherGCMOptions): CipherGCM;
+export function createCipheriv(
+  algorithm: CipherCCMTypes,
+  key: CipherKey,
+  iv: BinaryLike,
+  options: CipherCCMOptions
+): CipherCCM;
+export function createCipheriv(
+  algorithm: CipherOCBTypes,
+  key: CipherKey,
+  iv: BinaryLike,
+  options: CipherOCBOptions
+): CipherOCB;
+export function createCipheriv(
+  algorithm: CipherGCMTypes,
+  key: CipherKey,
+  iv: BinaryLike,
+  options?: CipherGCMOptions
+): CipherGCM;
 export function createCipheriv(
   algorithm: string,
-  key: BinaryLike,
+  key: CipherKey,
   iv: BinaryLike | null,
-  options?: Record<string, unknown> | Stream.TransformOptions
-): Cipher {
+  options?:
+    | CipherCCMOptions
+    | CipherOCBOptions
+    | CipherGCMOptions
+    | Stream.TransformOptions
+): CipherCCM | CipherOCB | CipherGCM | Cipher {
   return new Cipher(algorithm, key, options, iv);
 }
 

--- a/src/Cipher.ts
+++ b/src/Cipher.ts
@@ -13,6 +13,7 @@ import {
   validateString,
   validateUint32,
   validateInt32,
+  type BinaryLikeNode,
 } from './Utils';
 import { type InternalCipher, RSAKeyVariant } from './NativeQuickCrypto/Cipher';
 import type {
@@ -25,7 +26,6 @@ import type {
   DecipherGCM,
   DecipherOCB,
   DecipherCCM,
-  CipherKey,
   CipherCCM,
   CipherOCB,
   CipherGCM,
@@ -108,7 +108,7 @@ class CipherCommon extends Stream.Transform {
 
   constructor(
     cipherType: string,
-    cipherKey: CipherKey,
+    cipherKey: BinaryLikeNode,
     isCipher: boolean,
     options: Record<string, any> = {},
     iv?: BinaryLike | null
@@ -219,7 +219,7 @@ class CipherCommon extends Stream.Transform {
 class Cipher extends CipherCommon {
   constructor(
     cipherType: string,
-    cipherKey: CipherKey,
+    cipherKey: BinaryLikeNode,
     options: Record<string, any> = {},
     iv?: BinaryLike | null
   ) {
@@ -233,7 +233,7 @@ class Cipher extends CipherCommon {
 class Decipher extends CipherCommon {
   constructor(
     cipherType: string,
-    cipherKey: CipherKey,
+    cipherKey: BinaryLikeNode,
     options: Record<string, any> = {},
     iv?: BinaryLike | null
   ) {
@@ -247,17 +247,17 @@ class Decipher extends CipherCommon {
 
 export function createDecipher(
   algorithm: CipherCCMTypes,
-  password: CipherKey,
+  password: BinaryLikeNode,
   options: CipherCCMOptions
 ): DecipherCCM;
 export function createDecipher(
   algorithm: CipherGCMTypes,
-  password: CipherKey,
+  password: BinaryLikeNode,
   options?: CipherGCMOptions
 ): DecipherGCM;
 export function createDecipher(
   algorithm: string,
-  password: CipherKey,
+  password: BinaryLikeNode,
   options?: CipherCCMOptions | CipherGCMOptions | Stream.TransformOptions
 ): DecipherCCM | DecipherGCM | Decipher {
   return new Decipher(algorithm, password, options);
@@ -265,25 +265,25 @@ export function createDecipher(
 
 export function createDecipheriv(
   algorithm: CipherCCMTypes,
-  key: CipherKey,
+  key: BinaryLikeNode,
   iv: BinaryLike,
   options: CipherCCMOptions
 ): DecipherCCM;
 export function createDecipheriv(
   algorithm: CipherOCBTypes,
-  key: CipherKey,
+  key: BinaryLikeNode,
   iv: BinaryLike,
   options: CipherOCBOptions
 ): DecipherOCB;
 export function createDecipheriv(
   algorithm: CipherGCMTypes,
-  key: CipherKey,
+  key: BinaryLikeNode,
   iv: BinaryLike,
   options?: CipherGCMOptions
 ): DecipherGCM;
 export function createDecipheriv(
   algorithm: string,
-  key: CipherKey,
+  key: BinaryLikeNode,
   iv: BinaryLike | null,
   options?:
     | CipherCCMOptions
@@ -296,17 +296,17 @@ export function createDecipheriv(
 
 export function createCipher(
   algorithm: CipherCCMTypes,
-  password: CipherKey,
+  password: BinaryLikeNode,
   options: CipherCCMOptions
 ): CipherCCM;
 export function createCipher(
   algorithm: CipherGCMTypes,
-  password: CipherKey,
+  password: BinaryLikeNode,
   options?: CipherGCMOptions
 ): CipherGCM;
 export function createCipher(
   algorithm: string,
-  password: CipherKey,
+  password: BinaryLikeNode,
   options?: CipherGCMOptions | CipherCCMOptions | Stream.TransformOptions
 ): CipherCCM | CipherGCM | Cipher {
   return new Cipher(algorithm, password, options);
@@ -314,25 +314,25 @@ export function createCipher(
 
 export function createCipheriv(
   algorithm: CipherCCMTypes,
-  key: CipherKey,
+  key: BinaryLikeNode,
   iv: BinaryLike,
   options: CipherCCMOptions
 ): CipherCCM;
 export function createCipheriv(
   algorithm: CipherOCBTypes,
-  key: CipherKey,
+  key: BinaryLikeNode,
   iv: BinaryLike,
   options: CipherOCBOptions
 ): CipherOCB;
 export function createCipheriv(
   algorithm: CipherGCMTypes,
-  key: CipherKey,
+  key: BinaryLikeNode,
   iv: BinaryLike,
   options?: CipherGCMOptions
 ): CipherGCM;
 export function createCipheriv(
   algorithm: string,
-  key: CipherKey,
+  key: BinaryLikeNode,
   iv: BinaryLike | null,
   options?:
     | CipherCCMOptions

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -10,7 +10,7 @@ import type {
   SignVerifyAlgorithm,
   SubtleAlgorithm,
 } from './keys';
-import { KeyObject, type CipherKey } from 'crypto'; // @types/node
+import { type CipherKey } from 'crypto'; // @types/node
 
 export type BufferLike = ArrayBuffer | Buffer | ArrayBufferView;
 export type BinaryLike = string | ArrayBuffer | Buffer;
@@ -165,17 +165,10 @@ export function binaryLikeToArrayBuffer(
     return input.buffer;
   }
 
-  // Node has a new class called KeyObject. Our types have to support it
-  // to stay compatible with Node's types. But we don't support it yet.
-  if (input instanceof KeyObject) {
-    throw new Error(
-      'The node KeyObject class is not yet supported by react-native-quick-crypto'
-    );
-  }
-
   if (!(input instanceof ArrayBuffer)) {
     try {
       // this is a strange fallback case and input is unknown at this point
+      // @ts-expect-error
       const buffer = Buffer.from(input);
       return buffer.buffer.slice(
         buffer.byteOffset,
@@ -185,6 +178,8 @@ export function binaryLikeToArrayBuffer(
       throw 'error';
     }
   }
+
+  // TODO: handle if input is KeyObject?
 
   return input;
 }

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -14,6 +14,7 @@ import { type CipherKey } from 'crypto'; // @types/node
 
 export type BufferLike = ArrayBuffer | Buffer | ArrayBufferView;
 export type BinaryLike = string | ArrayBuffer | Buffer;
+export type BinaryLikeNode = CipherKey | BinaryLike;
 
 export type BinaryToTextEncoding = 'base64' | 'base64url' | 'hex' | 'binary';
 export type CharacterEncoding = 'utf8' | 'utf-8' | 'utf16le' | 'latin1';

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -10,7 +10,7 @@ import type {
   SignVerifyAlgorithm,
   SubtleAlgorithm,
 } from './keys';
-import type { CipherKey } from 'crypto'; // @types/node
+import { KeyObject, type CipherKey } from 'crypto'; // @types/node
 
 export type BufferLike = ArrayBuffer | Buffer | ArrayBufferView;
 export type BinaryLike = string | ArrayBuffer | Buffer;
@@ -165,11 +165,17 @@ export function binaryLikeToArrayBuffer(
     return input.buffer;
   }
 
+  // Node has a new class called KeyObject. Our types have to support it
+  // to stay compatible with Node's types. But we don't support it yet.
+  if (input instanceof KeyObject) {
+    throw new Error(
+      'The node KeyObject class is not yet supported by react-native-quick-crypto'
+    );
+  }
+
   if (!(input instanceof ArrayBuffer)) {
     try {
       // this is a strange fallback case and input is unknown at this point
-      // in Node it could be of type KeyObject but in this env we never pass that
-      // @ts-expect-error
       const buffer = Buffer.from(input);
       return buffer.buffer.slice(
         buffer.byteOffset,

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -139,7 +139,7 @@ export function bufferLikeToArrayBuffer(buf: BufferLike): ArrayBuffer {
 }
 
 export function binaryLikeToArrayBuffer(
-  input: BinaryLike | CipherKey, // CipherKey adds compat with node types
+  input: BinaryLikeNode, // CipherKey adds compat with node types
   encoding: string = 'utf-8'
 ): ArrayBuffer {
   if (typeof input === 'string') {

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -10,6 +10,7 @@ import type {
   SignVerifyAlgorithm,
   SubtleAlgorithm,
 } from './keys';
+import type { CipherKey } from 'crypto'; // @types/node
 
 export type BufferLike = ArrayBuffer | Buffer | ArrayBufferView;
 export type BinaryLike = string | ArrayBuffer | Buffer;
@@ -137,7 +138,7 @@ export function bufferLikeToArrayBuffer(buf: BufferLike): ArrayBuffer {
 }
 
 export function binaryLikeToArrayBuffer(
-  input: BinaryLike,
+  input: BinaryLike | CipherKey, // CipherKey adds compat with node types
   encoding: string = 'utf-8'
 ): ArrayBuffer {
   if (typeof input === 'string') {
@@ -166,6 +167,9 @@ export function binaryLikeToArrayBuffer(
 
   if (!(input instanceof ArrayBuffer)) {
     try {
+      // this is a strange fallback case and input is unknown at this point
+      // in Node it could be of type KeyObject but in this env we never pass that
+      // @ts-expect-error
       const buffer = Buffer.from(input);
       return buffer.buffer.slice(
         buffer.byteOffset,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2695,10 +2695,12 @@
   dependencies:
     undici-types "~5.26.4"
 
-"@types/node@^17.0.31":
-  version "17.0.45"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.45.tgz#2c0fafd78705e7a18b7906b5201a522719dc5190"
-  integrity sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==
+"@types/node@^20.12.7":
+  version "20.12.7"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.12.7.tgz#04080362fa3dd6c5822061aa3124f5c152cff384"
+  integrity sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg==
+  dependencies:
+    undici-types "~5.26.4"
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.4"


### PR DESCRIPTION
@mrousavy asked me to fix the types for cipher in #245 so I took a crack at it

Node uses a type called CipherKey which is a combination of BinaryLike and a new class called KeyObject. I am not sure if we support KeyObject but we're forced to declare support for it if we want to follow Node's type definitions for crypto. 

I added a TODO in case it should be supported in the conversion util