### PR TITLE
Fixed missing var for OpenSSL 3.+

### DIFF
--- a/cpp/Cipher/MGLCipherHostObject.cpp
+++ b/cpp/Cipher/MGLCipherHostObject.cpp
@@ -603,7 +603,7 @@ bool MGLCipherHostObject::InitAuthenticated(const char *cipher_type, int iv_len,
 #if OPENSSL_VERSION_MAJOR >= 3
     // TODO: not sure where kind_ comes from in next line, but as we bump
     // OpenSSL version we will need to look at Node.js code and figure it out.
-    if (mode == EVP_CIPH_CCM_MODE && kind_ == kDecipher &&
+    if (mode == EVP_CIPH_CCM_MODE && !isCipher_ &&
         EVP_default_properties_is_fips_enabled(nullptr)) {
 #else
     if (mode == EVP_CIPH_CCM_MODE && !isCipher_ && FIPS_mode()) {


### PR DESCRIPTION
- Replaced missing var with currently used validation.

Original code from node/crypto:
https://github.com/nodejs/node/blob/9ef03f1c237f509cb965d90c5cb301e99be80208/src/crypto/crypto_cipher.cc#L597

Var used by react-native-quick-crypto:
https://github.com/margelo/react-native-quick-crypto/blob/96df943a89ddbd92c3067edd725fc57aa4633e07/cpp/Cipher/MGLCipherHostObject.cpp#L609