### PR TITLE
fix: getAuthTag returning a value of -1 bytes

### DIFF
--- a/example/src/testing/Tests/CipherTests/CipherTestSecond.ts
+++ b/example/src/testing/Tests/CipherTests/CipherTestSecond.ts
@@ -76,6 +76,10 @@ describe('createCipheriv/createDecipheriv', () => {
     it('AES-GCM with key and iv ', () => {
       const plaintext = 'Hello, world!';
 
+      const defaultCipher = crypto.createCipheriv('aes-256-gcm', key, iv);
+      const defaultAuthTag = defaultCipher.getAuthTag();
+      assert.strictEqual(Buffer.from(defaultAuthTag).length, 16);
+
       // Encryption
       const cipher = crypto.createCipheriv('aes-256-gcm', key, iv, {
         // using an uncommon auth tag length for corner case checking. default is usually 16.

--- a/src/Cipher.ts
+++ b/src/Cipher.ts
@@ -116,7 +116,9 @@ class CipherCommon extends Stream.Transform {
     super(options);
     const cipherKeyBuffer = binaryLikeToArrayBuffer(cipherKey);
     // defaults to 16 bytes
-    const authTagLength = getUIntOption(options, 'authTagLength') !== -1 ? getUIntOption(options, 'authTagLength') : 16;
+    const authTagLength =
+      getUIntOption(options, 'authTagLength') !== -1
+        ? getUIntOption(options, 'authTagLength')
     const args = {
       cipher_type: cipherType,
       cipher_key: cipherKeyBuffer,

--- a/src/Cipher.ts
+++ b/src/Cipher.ts
@@ -115,8 +115,8 @@ class CipherCommon extends Stream.Transform {
   ) {
     super(options);
     const cipherKeyBuffer = binaryLikeToArrayBuffer(cipherKey);
-    // TODO(osp) This might not be smart, check again after release
-    const authTagLength = getUIntOption(options, 'authTagLength');
+    // defaults to 16 bytes
+    const authTagLength = getUIntOption(options, 'authTagLength') !== -1 ? getUIntOption(options, 'authTagLength') : 16;
     const args = {
       cipher_type: cipherType,
       cipher_key: cipherKeyBuffer,

--- a/src/Cipher.ts
+++ b/src/Cipher.ts
@@ -119,6 +119,7 @@ class CipherCommon extends Stream.Transform {
     const authTagLength =
       getUIntOption(options, 'authTagLength') !== -1
         ? getUIntOption(options, 'authTagLength')
+        : 16;
     const args = {
       cipher_type: cipherType,
       cipher_key: cipherKeyBuffer,


### PR DESCRIPTION
authTagLength was set equal to -1, which would result in an auth tag length of 4294967295, way above the Hermes limit of 256 MB