### PR TITLE
fix: broken cjs export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,5 +7,5 @@ global.Buffer = Buffer;
 // @ts-expect-error subtle isn't full implemented and Cryptokey is missing
 global.crypto = QuickCrypto;
 
-module.exports = crypto;
-export default crypto;
+module.exports = QuickCrypto;
+export default QuickCrypto;

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,4 +7,5 @@ global.Buffer = Buffer;
 // @ts-expect-error subtle isn't full implemented and Cryptokey is missing
 global.crypto = QuickCrypto;
 
-export default QuickCrypto;
+module.exports = crypto;
+export default crypto;


### PR DESCRIPTION
bug in rc1 where cjs export is broken when global namespace is used