### PR TITLE
fix: subtle importKey algorithm as string

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -320,7 +320,7 @@ PODS:
   - react-native-quick-base64 (2.1.2):
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
-  - react-native-quick-crypto (0.7.0-rc.0):
+  - react-native-quick-crypto (0.7.0-rc.2):
     - OpenSSL-Universal
     - React
     - React-callinvoker
@@ -636,7 +636,7 @@ SPEC CHECKSUMS:
   React-jsinspector: 8baadae51f01d867c3921213a25ab78ab4fbcd91
   React-logger: 8edc785c47c8686c7962199a307015e2ce9a0e4f
   react-native-quick-base64: 61228d753294ae643294a75fece8e0e80b7558a6
-  react-native-quick-crypto: a0fa8ca4681bd2cc989dc4daf166d58976bd068e
+  react-native-quick-crypto: bb67be1d66989d99ebe35cc617009d8c15225be5
   react-native-safe-area-context: 2cd91d532de12acdb0a9cbc8d43ac72a8e4c897c
   React-NativeModulesApple: b6868ee904013a7923128892ee4a032498a1024a
   React-perflogger: 31ea61077185eb1428baf60c0db6e2886f141a5a

--- a/example/src/testing/Tests/webcryptoTests/import_export.ts
+++ b/example/src/testing/Tests/webcryptoTests/import_export.ts
@@ -200,6 +200,22 @@ describe('subtle - importKey / exportKey', () => {
       expect(actual).to.equal(expected, 'import raw, export raw');
     });
 
+    it('importKey, raw, AES-GCM string algo', async () => {
+      const rawKeyData = crypto.getRandomValues(new Uint8Array(32));
+      const keyData = binaryLikeToArrayBuffer(rawKeyData);
+
+      const key = await subtle.importKey(
+        'raw',
+        keyData,
+        'AES-GCM',
+        false,
+        // eslint-disable-next-line prettier/prettier
+        ['encrypt', 'decrypt'],
+      );
+      expect(key.keyAlgorithm.name).to.equal('AES-GCM');
+      expect(key.keyAlgorithm.length).to.equal(256);
+    });
+
     const test = (rawKeyData: Uint8Array, descr: string): void => {
       it(`AES import raw / export jwk (${descr})`, async () => {
         const keyData = binaryLikeToArrayBuffer(rawKeyData);

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -439,25 +439,29 @@ const kSupportedAlgorithms: SupportedAlgorithms = {
   },
 };
 
-// const simpleAlgorithmDictionaries = {
-//   AesGcmParams: { iv: 'BufferSource', additionalData: 'BufferSource' },
-//   RsaHashedKeyGenParams: { hash: 'HashAlgorithmIdentifier' },
-//   EcKeyGenParams: {},
-//   HmacKeyGenParams: { hash: 'HashAlgorithmIdentifier' },
-//   RsaPssParams: {},
-//   EcdsaParams: { hash: 'HashAlgorithmIdentifier' },
-//   HmacImportParams: { hash: 'HashAlgorithmIdentifier' },
-//   HkdfParams: {
-//     hash: 'HashAlgorithmIdentifier',
-//     salt: 'BufferSource',
-//     info: 'BufferSource',
-//   },
-//   Ed448Params: { context: 'BufferSource' },
-//   Pbkdf2Params: { hash: 'HashAlgorithmIdentifier', salt: 'BufferSource' },
-//   RsaOaepParams: { label: 'BufferSource' },
-//   RsaHashedImportParams: { hash: 'HashAlgorithmIdentifier' },
-//   EcKeyImportParams: {},
-// };
+type AlgorithmDictionaries = {
+  [key in string]: Object;
+};
+
+const simpleAlgorithmDictionaries: AlgorithmDictionaries = {
+  AesGcmParams: { iv: 'BufferSource', additionalData: 'BufferSource' },
+  RsaHashedKeyGenParams: { hash: 'HashAlgorithmIdentifier' },
+  EcKeyGenParams: {},
+  HmacKeyGenParams: { hash: 'HashAlgorithmIdentifier' },
+  RsaPssParams: {},
+  EcdsaParams: { hash: 'HashAlgorithmIdentifier' },
+  HmacImportParams: { hash: 'HashAlgorithmIdentifier' },
+  HkdfParams: {
+    hash: 'HashAlgorithmIdentifier',
+    salt: 'BufferSource',
+    info: 'BufferSource',
+  },
+  Ed448Params: { context: 'BufferSource' },
+  Pbkdf2Params: { hash: 'HashAlgorithmIdentifier', salt: 'BufferSource' },
+  RsaOaepParams: { label: 'BufferSource' },
+  RsaHashedImportParams: { hash: 'HashAlgorithmIdentifier' },
+  EcKeyImportParams: {},
+};
 
 export const validateMaxBufferLength = (
   data: BinaryLike | BufferLike,
@@ -512,50 +516,47 @@ export const normalizeAlgorithm = (
   // Fast path everything below if the registered dictionary is null
   if (desiredType === null) return { name: algName };
 
-  throw lazyDOMException(
-    `normalizeAlgorithm() not implemented for ${op} / ${algName} / ${desiredType}`,
-    'NotSupportedError'
-  );
-  // TODO: implement these below when needed
-
-  // // 8.
-  // const normalizedAlgorithm = webidl.converters[desiredType](algorithm, {
+  // 6.
+  const normalizedAlgorithm = algorithm;
+  // TODO: implement this?  Maybe via typescript?
+  // webidl.converters[desiredType](algorithm, {
   //   prefix: 'Failed to normalize algorithm',
   //   context: 'passed algorithm',
   // });
-  // // 9.
-  // normalizedAlgorithm.name = algName;
+  // 7.
+  normalizedAlgorithm.name = algName;
 
-  // // 9.
-  // const dict = simpleAlgorithmDictionaries[desiredType];
-  // // 10.
-  // const dictKeys = dict ? Object.keys(dict) : [];
-  // for (let i = 0; i < dictKeys.length; i++) {
-  //   const member = dictKeys[i];
-  //   if (!dict.hasOwnProperty(member)) continue;
-  //   const idlType = dict[member];
-  //   const idlValue = normalizedAlgorithm[member];
-  //   // 3.
-  //   if (idlType === 'BufferSource' && idlValue) {
-  //     const isView = ArrayBufferIsView(idlValue);
-  //     normalizedAlgorithm[member] = TypedArrayPrototypeSlice(
-  //       new Uint8Array(
-  //         isView ? getDataViewOrTypedArrayBuffer(idlValue) : idlValue,
-  //         isView ? getDataViewOrTypedArrayByteOffset(idlValue) : 0,
-  //         isView
-  //           ? getDataViewOrTypedArrayByteLength(idlValue)
-  //           : ArrayBufferPrototypeGetByteLength(idlValue)
-  //       )
-  //     );
-  //   } else if (idlType === 'HashAlgorithmIdentifier') {
-  //     normalizedAlgorithm[member] = normalizeAlgorithm(idlValue, 'digest');
-  //   } else if (idlType === 'AlgorithmIdentifier') {
-  //     // This extension point is not used by any supported algorithm (yet?)
-  //     throw lazyDOMException('Not implemented.', 'NotSupportedError');
-  //   }
-  // }
+  // 9.
+  const dict = simpleAlgorithmDictionaries[desiredType];
+  // 10.
+  const dictKeys = dict ? Object.keys(dict) : [];
+  for (let i = 0; i < dictKeys.length; i++) {
+    const member = dictKeys[i] || '';
+    if (!dict?.hasOwnProperty(member)) continue;
+    // TODO: implement this?  Maybe via typescript?
+    // const idlType = dict[member];
+    // const idlValue = normalizedAlgorithm[member];
+    // 3.
+    // if (idlType === 'BufferSource' && idlValue) {
+    //   const isView = ArrayBufferIsView(idlValue);
+    //   normalizedAlgorithm[member] = TypedArrayPrototypeSlice(
+    //     new Uint8Array(
+    //       isView ? getDataViewOrTypedArrayBuffer(idlValue) : idlValue,
+    //       isView ? getDataViewOrTypedArrayByteOffset(idlValue) : 0,
+    //       isView
+    //         ? getDataViewOrTypedArrayByteLength(idlValue)
+    //         : ArrayBufferPrototypeGetByteLength(idlValue)
+    //     )
+    //   );
+    // } else if (idlType === 'HashAlgorithmIdentifier') {
+    //   normalizedAlgorithm[member] = normalizeAlgorithm(idlValue, 'digest');
+    // } else if (idlType === 'AlgorithmIdentifier') {
+    //   // This extension point is not used by any supported algorithm (yet?)
+    //   throw lazyDOMException('Not implemented.', 'NotSupportedError');
+    // }
+  }
 
-  // return normalizedAlgorithm;
+  return normalizedAlgorithm;
 };
 
 export const validateBitLength = (

--- a/src/subtle.ts
+++ b/src/subtle.ts
@@ -243,12 +243,13 @@ class Subtle {
   async importKey(
     format: ImportFormat,
     data: BufferLike | BinaryLike | JWK,
-    algorithm: SubtleAlgorithm,
+    algorithm: SubtleAlgorithm | AnyAlgorithm,
     extractable: boolean,
     keyUsages: KeyUsage[]
   ): Promise<CryptoKey> {
+    const normalizedAlgorithm = normalizeAlgorithm(algorithm, 'importKey');
     let result: CryptoKey;
-    switch (algorithm.name) {
+    switch (normalizedAlgorithm.name) {
       case 'RSASSA-PKCS1-v1_5':
       // Fall through
       case 'RSA-PSS':
@@ -257,7 +258,7 @@ class Subtle {
         result = rsaImportKey(
           format,
           data as BufferLike | JWK,
-          algorithm,
+          normalizedAlgorithm,
           extractable,
           keyUsages
         );
@@ -265,7 +266,13 @@ class Subtle {
       case 'ECDSA':
       // Fall through
       case 'ECDH':
-        result = ecImportKey(format, data, algorithm, extractable, keyUsages);
+        result = ecImportKey(
+          format,
+          data,
+          normalizedAlgorithm,
+          extractable,
+          keyUsages
+        );
         break;
       // case 'Ed25519':
       // // Fall through
@@ -299,7 +306,7 @@ class Subtle {
       // Fall through
       case 'AES-KW':
         result = await aesImportKey(
-          algorithm,
+          normalizedAlgorithm,
           format,
           data as BufferLike | JWK,
           extractable,
@@ -310,7 +317,7 @@ class Subtle {
       // // Fall through
       case 'PBKDF2':
         result = await importGenericSecretKey(
-          algorithm,
+          normalizedAlgorithm,
           format,
           data as BufferLike | BinaryLike,
           extractable,
@@ -319,7 +326,7 @@ class Subtle {
         break;
       default:
         throw new Error(
-          `"subtle.importKey()" is not implemented for ${algorithm.name}`
+          `"subtle.importKey()" is not implemented for ${normalizedAlgorithm.name}`
         );
     }
 


### PR DESCRIPTION
`subtle.importKey` was not supporting `AlgorithmIdentifier` type of `SubtleAlgorithm | AnyAlgorithm`, just `SubtleAlgorithm`.  So you would get an error when you try something like this:

```ts
const key = await subtle.importKey(
  'raw',
  keyData,
  'AES-GCM',   // <- string, not object
  false,
  ['encrypt', 'decrypt'],
);
```

Strings (of supported algorithms, i.e. `AnyAlgorithm`) should be valid for the `algorithm` argument.  This PR fixes the bug.