### PR TITLE
fix: rn source import corrected, key argument type error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-quick-crypto",
-  "version": "0.7.0-rc.2",
+  "version": "0.7.0-rc.3",
   "description": "A fast implementation of Node's `crypto` module written in C/C++ JSI",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/commonjs/index",
   "module": "lib/module/index",
   "types": "lib/typescript/src/index.d.ts",
-  "react-native": "lib/module/index",
+  "react-native": "src/index",
   "source": "src/index",
   "files": [
     "src",

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -417,7 +417,7 @@ export function parsePrivateKeyEncoding(
 }
 
 function prepareSecretKey(
-  key: any, //KeyObject | CryptoKey | string,
+  key: ArrayBuffer | KeyObject | CryptoKey | string,
   encoding?: string,
   bufferOnly = false
 ): any {
@@ -448,7 +448,9 @@ function prepareSecretKey(
     return binaryLikeToArrayBuffer(key, encoding);
   }
 
-  throw new Error('invalid argument type "key"');
+  throw new Error(
+    'Invalid argument type for "key". Need ArrayBuffer, KeyObject, CryptoKey, string'
+  );
 }
 
 export function createSecretKey(key: any, encoding?: string) {


### PR DESCRIPTION
`package.json` had the `react-native` directive pointing to lib, not src.

While testing in RN app, a less-than-desscriptive message ate some time for `key` argument type.  Added a bit more detail as well as typescript annotations.