### PR TITLE
use transpiled esm for app bundles

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/commonjs/index",
   "module": "lib/module/index",
   "types": "lib/typescript/src/index.d.ts",
-  "react-native": "src/index",
+  "react-native": "lib/module/index",
   "source": "src/index",
   "files": [
     "src",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,10 @@
     "skipLibCheck": true,
     "strict": true,
     "target": "esnext",
-    "verbatimModuleSyntax": true
+    "verbatimModuleSyntax": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
   },
   "include": [
     "src",


### PR DESCRIPTION
for consideration as an alternative to #294 

rather than requiring downstream projects to use typescript and transpile typescript using their own project's settings, we should transpile the typescript in this project and ship ESM with declarations, sourceMaps, and declarationMaps 