### PR TITLE
fix: android node_modules

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -5,7 +5,6 @@ set(PACKAGE_NAME "reactnativequickcrypto")
 set(BUILD_DIR ${CMAKE_SOURCE_DIR}/build)
 set(CMAKE_VERBOSE_MAKEFILE ON)
 set(CMAKE_CXX_STANDARD 17)
-set(NODE_MODULES_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../node_modules")
 
 # set (CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -g")
 # set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g")
@@ -48,7 +47,7 @@ add_library(
 )
 
 include_directories(
-  "../node_modules/react-native-quick-base64/cpp"
+  "${NODE_MODULES_DIR}/react-native-quick-base64/cpp"
 )
 
 target_include_directories(

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -112,7 +112,7 @@ android {
     externalNativeBuild {
       cmake {
         cppFlags "-O2 -frtti -fexceptions -Wall -Wno-unused-variable -fstack-protector-all"
-        arguments '-DANDROID_STL=c++_shared' , "-DNODE_MODULES_DIR=${nodeModules}",
+        arguments "-DANDROID_STL=c++_shared", "-DNODE_MODULES_DIR=${nodeModules}"
         abiFilters (*reactNativeArchitectures())
       }
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -48,22 +48,22 @@ def reactNativeArchitectures() {
   return value ? value.split(",") : ["armeabi-v7a", "x86", "x86_64", "arm64-v8a"]
 }
 
-// static def findNodeModules(baseDir) {
-//   def basePath = baseDir.toPath().normalize()
-//   // Node's module resolution algorithm searches up to the root directory,
-//   // after which the base path will be null
-//   while (basePath) {
-//     def nodeModulesPath = Paths.get(basePath.toString(), "node_modules")
-//     def reactNativePath = Paths.get(nodeModulesPath.toString(), "react-native")
-//     if (nodeModulesPath.toFile().exists() && reactNativePath.toFile().exists()) {
-//       return nodeModulesPath.toString()
-//     }
-//     basePath = basePath.getParent()
-//   }
-//   throw new GradleException("react-native-quick-crypto: Failed to find node_modules/ path!")
-// }
+static def findNodeModules(baseDir) {
+  def basePath = baseDir.toPath().normalize()
+  // Node's module resolution algorithm searches up to the root directory,
+  // after which the base path will be null
+  while (basePath) {
+    def nodeModulesPath = Paths.get(basePath.toString(), "node_modules")
+    def reactNativePath = Paths.get(nodeModulesPath.toString(), "react-native")
+    if (nodeModulesPath.toFile().exists() && reactNativePath.toFile().exists()) {
+      return nodeModulesPath.toString()
+    }
+    basePath = basePath.getParent()
+  }
+  throw new GradleException("react-native-quick-crypto: Failed to find node_modules/ path!")
+}
 
-// def nodeModules = findNodeModules(projectDir)
+def nodeModules = findNodeModules(projectDir)
 
 repositories {
   google()
@@ -112,7 +112,7 @@ android {
     externalNativeBuild {
       cmake {
         cppFlags "-O2 -frtti -fexceptions -Wall -Wno-unused-variable -fstack-protector-all"
-        arguments '-DANDROID_STL=c++_shared' //, "-DNODE_MODULES_DIR=${nodeModules}",
+        arguments '-DANDROID_STL=c++_shared' , "-DNODE_MODULES_DIR=${nodeModules}",
         abiFilters (*reactNativeArchitectures())
       }
     }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -320,7 +320,7 @@ PODS:
   - react-native-quick-base64 (2.1.2):
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
-  - react-native-quick-crypto (0.7.0-rc.2):
+  - react-native-quick-crypto (0.7.0-rc.4):
     - OpenSSL-Universal
     - React
     - React-callinvoker
@@ -636,7 +636,7 @@ SPEC CHECKSUMS:
   React-jsinspector: 8baadae51f01d867c3921213a25ab78ab4fbcd91
   React-logger: 8edc785c47c8686c7962199a307015e2ce9a0e4f
   react-native-quick-base64: 61228d753294ae643294a75fece8e0e80b7558a6
-  react-native-quick-crypto: bb67be1d66989d99ebe35cc617009d8c15225be5
+  react-native-quick-crypto: 416e74d9a364587b3b79972e0f0d7f2c653c7fb3
   react-native-safe-area-context: 2cd91d532de12acdb0a9cbc8d43ac72a8e4c897c
   React-NativeModulesApple: b6868ee904013a7923128892ee4a032498a1024a
   React-perflogger: 31ea61077185eb1428baf60c0db6e2886f141a5a

--- a/example/src/testing/Tests/webcryptoTests/import_export.ts
+++ b/example/src/testing/Tests/webcryptoTests/import_export.ts
@@ -91,7 +91,7 @@ describe('subtle - importKey / exportKey', () => {
         await subtle.importKey('raw', 1, { name: 'PBKDF2' }, false, [
           'deriveBits',
         ]),
-      'invalid argument type "key"'
+      'Invalid argument type for "key". Need ArrayBuffer, KeyObject, CryptoKey, string'
     );
     await assertThrowsAsync(
       async () =>


### PR DESCRIPTION
I commented out gradle's handling of the `NODE_MODULES_DIR` environment variable in #233 for some unknown reason 🤡 .

This PR puts that mechanism back, and hopefully handles the following:

fixes #291 
closes #297

Also, this fixes a regression in a `subtle.importKey` test, introduced in #294 
