### PR TITLE
feat: `subtle.generateKey` support for `ecdsa`, `ecdh`

### DIFF
--- a/cpp/Cipher/MGLGenerateKeyPairInstaller.cpp
+++ b/cpp/Cipher/MGLGenerateKeyPairInstaller.cpp
@@ -83,7 +83,7 @@ FieldDefinition getGenerateKeyPairFieldDefinition(
                     try {
                       jsCallInvoker->invokeAsync([&runtime, resolve,
                           variant, rsaConfig, ecConfig]() {
-                        std::pair<JSVariant, JSVariant> keys;
+                        std::pair<jsi::Value, jsi::Value> keys;
 
                         // switch on variant to get proper generateKeyPair
                         if (variant == kvRSA_SSA_PKCS1_v1_5 ||
@@ -99,13 +99,11 @@ FieldDefinition getGenerateKeyPairFieldDefinition(
                             + std::to_string((int)variant));
                         }
 
-                        auto publicKey = toJSI(runtime, keys.first);
-                        auto privateKey = toJSI(runtime, keys.second);
                         auto res = jsi::Array::createWithElements(
                           runtime,
                           jsi::Value::undefined(),
-                          publicKey,
-                          privateKey);
+                          keys.first,
+                          keys.second);
                         resolve->asObject(runtime).asFunction(runtime).call(
                             runtime, std::move(res));
                       });

--- a/cpp/Cipher/MGLGenerateKeyPairInstaller.cpp
+++ b/cpp/Cipher/MGLGenerateKeyPairInstaller.cpp
@@ -10,6 +10,7 @@
 #include <iostream>
 #include <memory>
 #include <mutex>
+#include <string>
 #include <thread>
 #include <utility>
 
@@ -36,14 +37,39 @@ FieldDefinition getGenerateKeyPairFieldDefinition(
     std::shared_ptr<DispatchQueue::dispatch_queue> workerQueue) {
   return buildPair(
       "generateKeyPair", JSIF([=]) {
+
+        KeyVariant variant =
+          static_cast<KeyVariant>((int)arguments[0].asNumber());
+        std::shared_ptr<RsaKeyPairGenConfig> rsaConfig;
+        std::shared_ptr<EcKeyPairGenConfig> ecConfig;
+
+        // switch on variant to get proper config from arguments
+        // outside of lambda 🤮
+        if (variant == kvRSA_SSA_PKCS1_v1_5 ||
+            variant == kvRSA_PSS ||
+            variant == kvRSA_OAEP
+        ) {
+          rsaConfig = std::make_shared<RsaKeyPairGenConfig>(
+            prepareRsaKeyGenConfig(runtime, arguments));
+        } else
+        if (variant == kvEC) {
+          ecConfig = std::make_shared<EcKeyPairGenConfig>(
+            prepareEcKeyGenConfig(runtime, arguments));
+        } else {
+          throw std::runtime_error("KeyVariant not implemented"
+            + std::to_string((int)variant));
+        }
+
         auto promiseConstructor =
             runtime.global().getPropertyAsFunction(runtime, "Promise");
 
         auto promise = promiseConstructor.callAsConstructor(
             runtime,
             jsi::Function::createFromHostFunction(
-                runtime, jsi::PropNameID::forAscii(runtime, "executor"), 2,
-                [&jsCallInvoker, arguments](
+                runtime,
+                jsi::PropNameID::forAscii(runtime, "executor"),
+                4,
+                [&jsCallInvoker, variant, rsaConfig, ecConfig](
                     jsi::Runtime &runtime, const jsi::Value &,
                     const jsi::Value *promiseArgs, size_t) -> jsi::Value {
                   auto resolve =
@@ -51,30 +77,26 @@ FieldDefinition getGenerateKeyPairFieldDefinition(
                   auto reject =
                       std::make_shared<jsi::Value>(runtime, promiseArgs[1]);
 
-                  std::thread t([&runtime, resolve, reject,
-                                 jsCallInvoker, arguments]() {
+                  std::thread t([&runtime, resolve, reject, jsCallInvoker,
+                      variant, rsaConfig, ecConfig]() {
                     m.lock();
                     try {
-                      jsCallInvoker->invokeAsync([&runtime, arguments, resolve]() {
+                      jsCallInvoker->invokeAsync([&runtime, resolve,
+                          variant, rsaConfig, ecConfig]() {
                         std::pair<JSVariant, JSVariant> keys;
-                        KeyVariant variant =
-                          static_cast<KeyVariant>((int)arguments[0].asNumber());
 
-                        // switch on variant to get proper config/genKeyPair
+                        // switch on variant to get proper generateKeyPair
                         if (variant == kvRSA_SSA_PKCS1_v1_5 ||
                             variant == kvRSA_PSS ||
                             variant == kvRSA_OAEP
                         ) {
-                          auto config = std::make_shared<RsaKeyPairGenConfig>(
-                            prepareRsaKeyGenConfig(runtime, arguments));
-                          keys = generateRsaKeyPair(runtime, config);
+                          keys = generateRsaKeyPair(runtime, rsaConfig);
                         } else
                         if (variant == kvEC) {
-                          auto config = std::make_shared<EcKeyPairGenConfig>(
-                            prepareEcKeyGenConfig(runtime, arguments));
-                          keys = generateEcKeyPair(runtime, config);
+                          keys = generateEcKeyPair(runtime, ecConfig);
                         } else {
-                          throw std::runtime_error("KeyVariant not implemented: " + variant);
+                          throw std::runtime_error("KeyVariant not implemented"
+                            + std::to_string((int)variant));
                         }
 
                         auto publicKey = toJSI(runtime, keys.first);

--- a/cpp/Cipher/MGLGenerateKeyPairSyncInstaller.cpp
+++ b/cpp/Cipher/MGLGenerateKeyPairSyncInstaller.cpp
@@ -37,7 +37,7 @@ FieldDefinition getGenerateKeyPairSyncFieldDefinition(
     std::shared_ptr<DispatchQueue::dispatch_queue> workerQueue) {
   return buildPair(
       "generateKeyPairSync", JSIF([=]) {
-        std::pair<JSVariant, JSVariant> keys;
+        std::pair<jsi::Value, jsi::Value> keys;
         KeyVariant variant =
             static_cast<KeyVariant>((int)arguments[0].asNumber());
 
@@ -57,11 +57,9 @@ FieldDefinition getGenerateKeyPairSyncFieldDefinition(
             } else {
                 throw std::runtime_error("KeyVariant not implemented: " + variant);
             }
-
-        auto publicKey = toJSI(runtime, keys.first);
-        auto privateKey = toJSI(runtime, keys.second);
+        // keys.first = publicKey   keys.second = privateKey
         return jsi::Array::createWithElements(
-            runtime, jsi::Value::undefined(), publicKey, privateKey);
+            runtime, jsi::Value::undefined(), keys.first, keys.second);
       });
 }
 }  // namespace margelo

--- a/cpp/Cipher/MGLGenerateKeyPairSyncInstaller.cpp
+++ b/cpp/Cipher/MGLGenerateKeyPairSyncInstaller.cpp
@@ -29,9 +29,6 @@ using namespace facebook;
 
 namespace margelo {
 
-// Current implementation only supports RSA schemes (check line config.variant =
-// ) As more encryption schemes are added this will require an abstraction that
-// supports more schemes
 FieldDefinition getGenerateKeyPairSyncFieldDefinition(
     std::shared_ptr<react::CallInvoker> jsCallInvoker,
     std::shared_ptr<DispatchQueue::dispatch_queue> workerQueue) {
@@ -41,22 +38,23 @@ FieldDefinition getGenerateKeyPairSyncFieldDefinition(
         KeyVariant variant =
             static_cast<KeyVariant>((int)arguments[0].asNumber());
 
-            // switch on variant to get proper config/genKeyPair
-            if (variant == kvRSA_SSA_PKCS1_v1_5 ||
-                variant == kvRSA_PSS ||
-                variant == kvRSA_OAEP
-            ) {
-                auto config = std::make_shared<RsaKeyPairGenConfig>(
-                  prepareRsaKeyGenConfig(runtime, arguments));
-                auto keys = generateRsaKeyPair(runtime, std::move(config));
-            } else
-            if (variant == kvEC) {
-                auto config = std::make_shared<EcKeyPairGenConfig>(
-                prepareEcKeyGenConfig(runtime, arguments));
-                keys = generateEcKeyPair(runtime, config);
-            } else {
-                throw std::runtime_error("KeyVariant not implemented: " + variant);
-            }
+        // switch on variant to get proper config/genKeyPair
+        if (variant == kvRSA_SSA_PKCS1_v1_5 ||
+            variant == kvRSA_PSS ||
+            variant == kvRSA_OAEP
+        ) {
+            auto config = std::make_shared<RsaKeyPairGenConfig>(
+                prepareRsaKeyGenConfig(runtime, arguments));
+            keys = generateRsaKeyPair(runtime, config);
+        } else
+        if (variant == kvEC) {
+            auto config = std::make_shared<EcKeyPairGenConfig>(
+            prepareEcKeyGenConfig(runtime, arguments));
+            keys = generateEcKeyPair(runtime, config);
+        } else {
+            throw std::runtime_error("KeyVariant not implemented: " +
+                std::to_string((int)variant));
+        }
         // keys.first = publicKey   keys.second = privateKey
         return jsi::Array::createWithElements(
             runtime, jsi::Value::undefined(), keys.first, keys.second);

--- a/cpp/Cipher/MGLRsa.cpp
+++ b/cpp/Cipher/MGLRsa.cpp
@@ -21,7 +21,7 @@ namespace jsi = facebook::jsi;
 
 EVPKeyCtxPointer setup(std::shared_ptr<RsaKeyPairGenConfig> config) {
   EVPKeyCtxPointer ctx(EVP_PKEY_CTX_new_id(
-      config->variant == kKeyVariantRSA_PSS ? EVP_PKEY_RSA_PSS : EVP_PKEY_RSA,
+      config->variant == kvRSA_PSS ? EVP_PKEY_RSA_PSS : EVP_PKEY_RSA,
       nullptr));
 
   if (EVP_PKEY_keygen_init(ctx.get()) <= 0) return EVPKeyCtxPointer();
@@ -43,7 +43,7 @@ EVPKeyCtxPointer setup(std::shared_ptr<RsaKeyPairGenConfig> config) {
     bn.release();
   }
 
-  if (config->variant == kKeyVariantRSA_PSS) {
+  if (config->variant == kvRSA_PSS) {
     if (config->md != nullptr &&
         EVP_PKEY_CTX_set_rsa_pss_keygen_md(ctx.get(), config->md) <= 0) {
       return EVPKeyCtxPointer();
@@ -94,12 +94,12 @@ RsaKeyPairGenConfig prepareRsaKeyGenConfig(jsi::Runtime& runtime,
   //    CHECK(args[*offset + 1]->IsUint32());  // Modulus bits
   //    CHECK(args[*offset + 2]->IsUint32());  // Exponent
   config.variant =
-      static_cast<RSAKeyVariant>((int)arguments[offset].asNumber());
+      static_cast<KeyVariant>((int)arguments[offset].asNumber());
 
   // TODO(osp)
-  //    CHECK_IMPLIES(params->params.variant != kKeyVariantRSA_PSS,
+  //    CHECK_IMPLIES(params->params.variant != RSA_PSS,
   //                  args.Length() == 10);
-  //    CHECK_IMPLIES(params->params.variant == kKeyVariantRSA_PSS,
+  //    CHECK_IMPLIES(params->params.variant == RSA_PSS,
   //                  args.Length() == 13);
   config.modulus_bits =
       static_cast<unsigned int>(arguments[offset + 1].asNumber());
@@ -107,7 +107,7 @@ RsaKeyPairGenConfig prepareRsaKeyGenConfig(jsi::Runtime& runtime,
 
   offset += 3;
 
-  if (config.variant == kKeyVariantRSA_PSS) {
+  if (config.variant == kvRSA_PSS) {
     if (!arguments[offset].isUndefined()) {
       // TODO(osp) CHECK(string)
       config.md = EVP_get_digestbyname(
@@ -153,8 +153,9 @@ RsaKeyPairGenConfig prepareRsaKeyGenConfig(jsi::Runtime& runtime,
   return config;
 }
 
-std::pair<JSVariant, JSVariant> generateRSAKeyPair(
+std::pair<JSVariant, JSVariant> generateRsaKeyPair(
     jsi::Runtime& runtime, std::shared_ptr<RsaKeyPairGenConfig> config) {
+  // TODO: this is all copied into crypto_ec.cpp - template it up like Node
   CheckEntropy();
 
   EVPKeyCtxPointer ctx = setup(config);

--- a/cpp/Cipher/MGLRsa.cpp
+++ b/cpp/Cipher/MGLRsa.cpp
@@ -155,7 +155,7 @@ RsaKeyPairGenConfig prepareRsaKeyGenConfig(jsi::Runtime& runtime,
 
 std::pair<jsi::Value, jsi::Value> generateRsaKeyPair(
     jsi::Runtime& runtime, std::shared_ptr<RsaKeyPairGenConfig> config) {
-  // TODO: this is all copied into crypto_ec.cpp - template it up like Node
+  // TODO: this is all copied into crypto_ec.cpp - template it up like Node?
   CheckEntropy();
 
   EVPKeyCtxPointer ctx = setup(config);

--- a/cpp/Cipher/MGLRsa.cpp
+++ b/cpp/Cipher/MGLRsa.cpp
@@ -97,9 +97,9 @@ RsaKeyPairGenConfig prepareRsaKeyGenConfig(jsi::Runtime& runtime,
       static_cast<KeyVariant>((int)arguments[offset].asNumber());
 
   // TODO(osp)
-  //    CHECK_IMPLIES(params->params.variant != RSA_PSS,
+  //    CHECK_IMPLIES(params->params.variant != kvRSA_PSS,
   //                  args.Length() == 10);
-  //    CHECK_IMPLIES(params->params.variant == RSA_PSS,
+  //    CHECK_IMPLIES(params->params.variant == kvRSA_PSS,
   //                  args.Length() == 13);
   config.modulus_bits =
       static_cast<unsigned int>(arguments[offset + 1].asNumber());

--- a/cpp/Cipher/MGLRsa.cpp
+++ b/cpp/Cipher/MGLRsa.cpp
@@ -179,11 +179,11 @@ std::pair<jsi::Value, jsi::Value> generateRsaKeyPair(
       ManagedEVPPKey::ToEncodedPrivateKey(runtime, std::move(config->key),
                                           config->private_key_encoding);
 
-  if (!publicBuffer.isUndefined() || !privateBuffer.isUndefined()) {
-    throw jsi::JSError(runtime, "Failed to encode public and/or private key");
+  if (publicBuffer.isUndefined() || privateBuffer.isUndefined()) {
+    throw jsi::JSError(runtime, "Failed to encode public and/or private key (RSA)");
   }
 
-  return {publicBuffer, privateBuffer};
+  return {std::move(publicBuffer), std::move(privateBuffer)};
 }
 
 jsi::Value ExportJWKRsaKey(jsi::Runtime &rt,

--- a/cpp/Cipher/MGLRsa.cpp
+++ b/cpp/Cipher/MGLRsa.cpp
@@ -153,7 +153,7 @@ RsaKeyPairGenConfig prepareRsaKeyGenConfig(jsi::Runtime& runtime,
   return config;
 }
 
-std::pair<JSVariant, JSVariant> generateRsaKeyPair(
+std::pair<jsi::Value, jsi::Value> generateRsaKeyPair(
     jsi::Runtime& runtime, std::shared_ptr<RsaKeyPairGenConfig> config) {
   // TODO: this is all copied into crypto_ec.cpp - template it up like Node
   CheckEntropy();
@@ -172,18 +172,18 @@ std::pair<JSVariant, JSVariant> generateRsaKeyPair(
 
   config->key = ManagedEVPPKey(EVPKeyPointer(pkey));
 
-  OptionJSVariant publicBuffer =
+  jsi::Value publicBuffer =
       ManagedEVPPKey::ToEncodedPublicKey(runtime, std::move(config->key),
                                          config->public_key_encoding);
-  OptionJSVariant privateBuffer =
+  jsi::Value privateBuffer =
       ManagedEVPPKey::ToEncodedPrivateKey(runtime, std::move(config->key),
                                           config->private_key_encoding);
 
-  if (!publicBuffer.has_value() || !privateBuffer.has_value()) {
+  if (!publicBuffer.isUndefined() || !privateBuffer.isUndefined()) {
     throw jsi::JSError(runtime, "Failed to encode public and/or private key");
   }
 
-  return {std::move(publicBuffer.value()), std::move(privateBuffer.value())};
+  return {publicBuffer, privateBuffer};
 }
 
 jsi::Value ExportJWKRsaKey(jsi::Runtime &rt,

--- a/cpp/Cipher/MGLRsa.h
+++ b/cpp/Cipher/MGLRsa.h
@@ -51,7 +51,7 @@ struct RsaKeyPairGenConfig {
 RsaKeyPairGenConfig prepareRsaKeyGenConfig(jsi::Runtime& runtime,
                                          const jsi::Value* arguments);
 
-std::pair<JSVariant, JSVariant> generateRsaKeyPair(
+std::pair<jsi::Value, jsi::Value> generateRsaKeyPair(
     jsi::Runtime& runtime, std::shared_ptr<RsaKeyPairGenConfig> config);
 
 jsi::Value ExportJWKRsaKey(jsi::Runtime &rt,

--- a/cpp/Cipher/MGLRsa.h
+++ b/cpp/Cipher/MGLRsa.h
@@ -25,12 +25,6 @@ namespace margelo {
 
 namespace jsi = facebook::jsi;
 
-enum RSAKeyVariant {
-  kKeyVariantRSA_SSA_PKCS1_v1_5,
-  kKeyVariantRSA_PSS,
-  kKeyVariantRSA_OAEP
-};
-
 // On node there is a complete madness of structs/classes that encapsulate and
 // initialize the data in a generic manner this is to be later be used to
 // generate the keys in a thread-safe manner (I think) I'm however too dumb and
@@ -43,7 +37,7 @@ struct RsaKeyPairGenConfig {
   PrivateKeyEncodingConfig private_key_encoding;
   ManagedEVPPKey key;
 
-  RSAKeyVariant variant;
+  KeyVariant variant;
   unsigned int modulus_bits;
   unsigned int exponent;
 
@@ -57,7 +51,7 @@ struct RsaKeyPairGenConfig {
 RsaKeyPairGenConfig prepareRsaKeyGenConfig(jsi::Runtime& runtime,
                                          const jsi::Value* arguments);
 
-std::pair<JSVariant, JSVariant> generateRSAKeyPair(
+std::pair<JSVariant, JSVariant> generateRsaKeyPair(
     jsi::Runtime& runtime, std::shared_ptr<RsaKeyPairGenConfig> config);
 
 jsi::Value ExportJWKRsaKey(jsi::Runtime &rt,

--- a/cpp/JSIUtils/MGLJSIUtils.h
+++ b/cpp/JSIUtils/MGLJSIUtils.h
@@ -9,6 +9,7 @@
 #define MGLJSIUtils_h
 
 #include <jsi/jsi.h>
+#include <limits>
 
 namespace jsi = facebook::jsi;
 
@@ -19,6 +20,14 @@ inline bool CheckIsArrayBuffer(jsi::Runtime &runtime, const jsi::Value &value) {
 
 inline bool CheckSizeInt32(jsi::Runtime &runtime, jsi::ArrayBuffer &buffer) {
   return buffer.size(runtime) <= INT_MAX;
+}
+
+inline bool CheckIsInt32(const jsi::Value &value) {
+  if (!value.isNumber()) {
+    return false;
+  }
+  double d = value.asNumber();
+  return (d >= std::numeric_limits<int32_t>::lowest() && d <= std::numeric_limits<int32_t>::max());
 }
 
 #endif /* MGLJSIUtils_h */

--- a/cpp/MGLKeys.cpp
+++ b/cpp/MGLKeys.cpp
@@ -561,8 +561,9 @@ jsi::Value ManagedEVPPKey::ToEncodedPublicKey(jsi::Runtime& rt,
     // Note that this has the downside of containing sensitive data of the
     // private key.
     auto data = KeyObjectData::CreateAsymmetric(kKeyTypePublic, std::move(key));
-    auto out = KeyObjectHandle::Create(rt, data);
-    return toJSI(rt, out);
+    auto handle = KeyObjectHandle::Create(rt, data);
+    auto out = jsi::Object::createFromHostObject(rt, handle);
+    return jsi::Value(std::move(out));
   } else
   if (config.format_ == kKeyFormatJWK) {
     throw std::runtime_error("ToEncodedPublicKey 2 (JWK) not implemented from node");
@@ -581,8 +582,9 @@ jsi::Value ManagedEVPPKey::ToEncodedPrivateKey(jsi::Runtime& rt,
   if (!key) return {};
   if (config.output_key_object_) {
     auto data = KeyObjectData::CreateAsymmetric(kKeyTypePrivate, std::move(key));
-    auto out = KeyObjectHandle::Create(rt, data);
-    return toJSI(rt, out);
+    auto handle = KeyObjectHandle::Create(rt, data);
+    auto out = jsi::Object::createFromHostObject(rt, handle);
+    return jsi::Value(std::move(out));
   } else
   if (config.format_ == kKeyFormatJWK) {
     throw std::runtime_error("ToEncodedPrivateKey 2 (JWK) not implemented from node");
@@ -892,9 +894,9 @@ jsi::Value KeyObjectHandle::get(
 //   registry->Register(Equals);
 // }
 
-KeyObjectHandle* KeyObjectHandle::Create(jsi::Runtime &rt,
-                                   std::shared_ptr<KeyObjectData> data) {
-  KeyObjectHandle* handle = new KeyObjectHandle();
+std::shared_ptr<KeyObjectHandle> KeyObjectHandle::Create(jsi::Runtime &rt,
+                                                         std::shared_ptr<KeyObjectData> data) {
+  auto handle = std::make_shared<KeyObjectHandle>();
   handle->data_ = data;
   return handle;
 }

--- a/cpp/MGLKeys.h
+++ b/cpp/MGLKeys.h
@@ -168,8 +168,8 @@ class JSI_EXPORT KeyObjectHandle: public jsi::HostObject {
     jsi::Value get(jsi::Runtime &rt, const jsi::PropNameID &propNameID);
     const std::shared_ptr<KeyObjectData>& Data();
 
-    static KeyObjectHandle* Create(jsi::Runtime &rt,
-                                   std::shared_ptr<KeyObjectData> data);
+    static std::shared_ptr<KeyObjectHandle> Create(jsi::Runtime &rt,
+                                                   std::shared_ptr<KeyObjectData> data);
 
  protected:
     jsi::Value Export(jsi::Runtime &rt);
@@ -189,17 +189,6 @@ class JSI_EXPORT KeyObjectHandle: public jsi::HostObject {
  private:
     std::shared_ptr<KeyObjectData> data_;
 };
-
-// Convert KeyObjectHandle to jsi::Value for shipping back to JS side.
-//
-// Note: This `toJSI()` is in MGLKeys for access to KeyObjectHandle. The rest of the `toJSI()` functions are in MGLUtils.
-inline jsi::Value toJSI(jsi::Runtime& rt, KeyObjectHandle* value) {
-  jsi::Function handle_ctor =
-    rt.global().getPropertyAsFunction(rt, "KeyObjectHandle");
-  jsi::Object o =
-    handle_ctor.callAsConstructor(rt, std::move(value)).getObject(rt);
-  return o;
-}
 
 }  // namespace margelo
 

--- a/cpp/MGLKeys.h
+++ b/cpp/MGLKeys.h
@@ -114,13 +114,13 @@ class ManagedEVPPKey {
                                             unsigned int *offset,
                                             bool allow_key_object);
 
-  static OptionJSVariant ToEncodedPublicKey(jsi::Runtime &runtime,
-                                            ManagedEVPPKey key,
-                                            const PublicKeyEncodingConfig &config);
+  static jsi::Value ToEncodedPublicKey(jsi::Runtime &runtime,
+                                       ManagedEVPPKey key,
+                                       const PublicKeyEncodingConfig &config);
 
-  static OptionJSVariant ToEncodedPrivateKey(jsi::Runtime &runtime,
-                                             ManagedEVPPKey key,
-                                             const PrivateKeyEncodingConfig &config);
+  static jsi::Value ToEncodedPrivateKey(jsi::Runtime &runtime,
+                                        ManagedEVPPKey key,
+                                        const PrivateKeyEncodingConfig &config);
 
  private:
    size_t size_of_private_key() const;
@@ -174,13 +174,13 @@ class JSI_EXPORT KeyObjectHandle: public jsi::HostObject {
  protected:
     jsi::Value Export(jsi::Runtime &rt);
     jsi::Value ExportJWK(jsi::Runtime &rt);
-    OptionJSVariant ExportPublicKey(
+    jsi::Value ExportPublicKey(
       jsi::Runtime& rt,
       const PublicKeyEncodingConfig& config) const;
-    OptionJSVariant ExportPrivateKey(
+    jsi::Value ExportPrivateKey(
       jsi::Runtime& rt,
       const PrivateKeyEncodingConfig& config) const;
-    OptionJSVariant ExportSecretKey(jsi::Runtime& rt) const;
+    jsi::Value ExportSecretKey(jsi::Runtime& rt) const;
     jsi::Value Init(jsi::Runtime &rt);
     jsi::Value InitECRaw(jsi::Runtime &rt);
     jsi::Value InitJWK(jsi::Runtime &rt);
@@ -189,6 +189,17 @@ class JSI_EXPORT KeyObjectHandle: public jsi::HostObject {
  private:
     std::shared_ptr<KeyObjectData> data_;
 };
+
+// Convert KeyObjectHandle to jsi::Value for shipping back to JS side.
+//
+// Note: This `toJSI()` is in MGLKeys for access to KeyObjectHandle. The rest of the `toJSI()` functions are in MGLUtils.
+inline jsi::Value toJSI(jsi::Runtime& rt, KeyObjectHandle* value) {
+  jsi::Function handle_ctor =
+    rt.global().getPropertyAsFunction(rt, "KeyObjectHandle");
+  jsi::Object o =
+    handle_ctor.callAsConstructor(rt, std::move(value)).getObject(rt);
+  return o;
+}
 
 }  // namespace margelo
 

--- a/cpp/MGLKeys.h
+++ b/cpp/MGLKeys.h
@@ -101,7 +101,8 @@ class ManagedEVPPKey {
       KeyEncodingContext context);
   //
   static ManagedEVPPKey GetParsedKey(jsi::Runtime &runtime,
-                                     EVPKeyPointer &&pkey, ParseKeyResult ret,
+                                     EVPKeyPointer &&pkey,
+                                     ParseKeyResult ret,
                                      const char *default_msg);
 
   static ManagedEVPPKey GetPublicOrPrivateKeyFromJs(jsi::Runtime &runtime,
@@ -113,17 +114,17 @@ class ManagedEVPPKey {
                                             unsigned int *offset,
                                             bool allow_key_object);
 
-  static OptionJSVariant ToEncodedPublicKey(
-      jsi::Runtime &runtime, ManagedEVPPKey key,
-      const PublicKeyEncodingConfig &config);
+  static OptionJSVariant ToEncodedPublicKey(jsi::Runtime &runtime,
+                                            ManagedEVPPKey key,
+                                            const PublicKeyEncodingConfig &config);
 
-  static OptionJSVariant ToEncodedPrivateKey(
-      jsi::Runtime &runtime, ManagedEVPPKey key,
-      const PrivateKeyEncodingConfig &config);
+  static OptionJSVariant ToEncodedPrivateKey(jsi::Runtime &runtime,
+                                             ManagedEVPPKey key,
+                                             const PrivateKeyEncodingConfig &config);
 
  private:
-  //  size_t size_of_private_key() const;
-  //  size_t size_of_public_key() const;
+   size_t size_of_private_key() const;
+   size_t size_of_public_key() const;
 
   EVPKeyPointer pkey_;
 };
@@ -166,6 +167,9 @@ class JSI_EXPORT KeyObjectHandle: public jsi::HostObject {
     KeyObjectHandle() {}
     jsi::Value get(jsi::Runtime &rt, const jsi::PropNameID &propNameID);
     const std::shared_ptr<KeyObjectData>& Data();
+
+    // static KeyObjectHandle Create(jsi::Runtime &rt,
+    //                               std::shared_ptr<KeyObjectData> data);
 
  protected:
     jsi::Value Export(jsi::Runtime &rt);

--- a/cpp/MGLKeys.h
+++ b/cpp/MGLKeys.h
@@ -168,8 +168,8 @@ class JSI_EXPORT KeyObjectHandle: public jsi::HostObject {
     jsi::Value get(jsi::Runtime &rt, const jsi::PropNameID &propNameID);
     const std::shared_ptr<KeyObjectData>& Data();
 
-    // static KeyObjectHandle Create(jsi::Runtime &rt,
-    //                               std::shared_ptr<KeyObjectData> data);
+    static KeyObjectHandle* Create(jsi::Runtime &rt,
+                                   std::shared_ptr<KeyObjectData> data);
 
  protected:
     jsi::Value Export(jsi::Runtime &rt);

--- a/cpp/Utils/MGLUtils.cpp
+++ b/cpp/Utils/MGLUtils.cpp
@@ -18,47 +18,6 @@ namespace margelo {
 
 namespace jsi = facebook::jsi;
 
-jsi::Value toJSI(jsi::Runtime& rt, OptionJSVariant& value) {
-  if (!value.has_value()) {
-    return jsi::Value::null();
-  }
-  try {
-    return toJSI(rt, value.value());
-  } catch (const std::bad_optional_access& e) {
-    std::cout << e.what() << '\n';
-  }
-  return jsi::Value::null();
-}
-
-jsi::Value toJSI(jsi::Runtime& rt, JSVariant& value) {
-  if (std::holds_alternative<bool>(value)) {
-    return jsi::Value(std::get<bool>(value));
-  } else if (std::holds_alternative<int>(value)) {
-    return jsi::Value(std::get<int>(value));
-  } else if (std::holds_alternative<long long>(value)) {
-    return jsi::Value(static_cast<double>(std::get<long long>(value)));
-  } else if (std::holds_alternative<double>(value)) {
-    return jsi::Value(std::get<double>(value));
-  } else if (std::holds_alternative<std::string>(value)) {
-    return jsi::String::createFromUtf8(rt, std::get<std::string>(value));
-  } else if (std::holds_alternative<ByteSource>(value)) {
-    ByteSource& source = std::get<ByteSource>(value);
-    jsi::Function array_buffer_ctor =
-        rt.global().getPropertyAsFunction(rt, "ArrayBuffer");
-    jsi::Object o = array_buffer_ctor.callAsConstructor(rt, (int)source.size())
-                        .getObject(rt);
-    jsi::ArrayBuffer buf = o.getArrayBuffer(rt);
-    // You cannot share raw memory between native and JS
-    // always copy the data
-    // see https://github.com/facebook/hermes/pull/419 and
-    // https://github.com/facebook/hermes/issues/564.
-    memcpy(buf.data(rt), source.data(), source.size());
-    return o;
-  }
-
-  return jsi::Value::null();
-}
-
 ByteSource ArrayBufferToByteSource(jsi::Runtime& runtime,
                                    const jsi::ArrayBuffer& buffer) {
   if (buffer.size(runtime) == 0) return ByteSource();

--- a/cpp/Utils/MGLUtils.h
+++ b/cpp/Utils/MGLUtils.h
@@ -278,6 +278,17 @@ std::string EncodeBignum(const BIGNUM* bn,
 std::string EncodeBase64(const std::string data, bool url = false);
 std::string DecodeBase64(const std::string &in, bool remove_linebreaks = false);
 
+// TODO: until shared, keep in sync with JS side (src/NativeQuickCrypto/Cipher.ts)
+enum KeyVariant {
+  kvRSA_SSA_PKCS1_v1_5,
+  kvRSA_PSS,
+  kvRSA_OAEP,
+  kvDSA,
+  kvEC,
+  kvNID,
+  kvDH,
+};
+
 }  // namespace margelo
 
 #endif /* MGLUtils_h */

--- a/cpp/webcrypto/MGLWebCrypto.cpp
+++ b/cpp/webcrypto/MGLWebCrypto.cpp
@@ -48,8 +48,7 @@ jsi::Value createWebCryptoObject(jsi::Runtime &rt) {
         if (status != WebCryptoKeyExportStatus::OK) {
             throw jsi::JSError(rt, "error exporting key, status: " + std::to_string(static_cast<int>(status)));
         }
-        JSVariant jsv = JSVariant(std::move(out));
-        return toJSI(rt, jsv);
+        return toJSI(rt, std::move(out));
     });
 
     obj.setProperty(rt,

--- a/cpp/webcrypto/crypto_ec.cpp
+++ b/cpp/webcrypto/crypto_ec.cpp
@@ -408,7 +408,7 @@ EVPKeyCtxPointer setup(std::shared_ptr<EcKeyPairGenConfig> config) {
 std::pair<jsi::Value, jsi::Value> generateEcKeyPair(jsi::Runtime& runtime,
                                                     std::shared_ptr<EcKeyPairGenConfig> config)
 {
-  // TODO: this is all copied from MGLRsa.cpp - template it up like Node
+  // TODO: this is all copied from MGLRsa.cpp - template it up like Node?
 
   EVPKeyCtxPointer ctx = setup(config);
 

--- a/cpp/webcrypto/crypto_ec.cpp
+++ b/cpp/webcrypto/crypto_ec.cpp
@@ -431,11 +431,11 @@ std::pair<jsi::Value, jsi::Value> generateEcKeyPair(jsi::Runtime& runtime,
       ManagedEVPPKey::ToEncodedPrivateKey(runtime, std::move(config->key),
                                           config->private_key_encoding);
 
-  if (!publicBuffer.isUndefined() || !privateBuffer.isUndefined()) {
-    throw jsi::JSError(runtime, "Failed to encode public and/or private key");
+  if (publicBuffer.isUndefined() || privateBuffer.isUndefined()) {
+    throw jsi::JSError(runtime, "Failed to encode public and/or private key (EC)");
   }
 
-  return {publicBuffer, privateBuffer};
+  return {std::move(publicBuffer), std::move(privateBuffer)};
 }
 
 } // namespace margelo

--- a/cpp/webcrypto/crypto_ec.cpp
+++ b/cpp/webcrypto/crypto_ec.cpp
@@ -405,8 +405,8 @@ EVPKeyCtxPointer setup(std::shared_ptr<EcKeyPairGenConfig> config) {
   return key_ctx;
 }
 
-std::pair<JSVariant, JSVariant> generateEcKeyPair(jsi::Runtime& runtime,
-                                                  std::shared_ptr<EcKeyPairGenConfig> config)
+std::pair<jsi::Value, jsi::Value> generateEcKeyPair(jsi::Runtime& runtime,
+                                                    std::shared_ptr<EcKeyPairGenConfig> config)
 {
   // TODO: this is all copied from MGLRsa.cpp - template it up like Node
 
@@ -424,19 +424,18 @@ std::pair<JSVariant, JSVariant> generateEcKeyPair(jsi::Runtime& runtime,
 
   config->key = ManagedEVPPKey(EVPKeyPointer(pkey));
 
-  OptionJSVariant publicBuffer =
+  jsi::Value publicBuffer =
       ManagedEVPPKey::ToEncodedPublicKey(runtime, std::move(config->key),
                                          config->public_key_encoding);
-  OptionJSVariant privateBuffer =
+  jsi::Value privateBuffer =
       ManagedEVPPKey::ToEncodedPrivateKey(runtime, std::move(config->key),
                                           config->private_key_encoding);
 
-  if (!publicBuffer.has_value() || !privateBuffer.has_value()) {
+  if (!publicBuffer.isUndefined() || !privateBuffer.isUndefined()) {
     throw jsi::JSError(runtime, "Failed to encode public and/or private key");
   }
 
-  return {std::move(publicBuffer.value()), std::move(privateBuffer.value())};
-
+  return {publicBuffer, privateBuffer};
 }
 
 } // namespace margelo

--- a/cpp/webcrypto/crypto_ec.cpp
+++ b/cpp/webcrypto/crypto_ec.cpp
@@ -15,10 +15,6 @@
 namespace margelo {
 namespace jsi = facebook::jsi;
 
-int GetCurveFromName(std::string name) {
-  return GetCurveFromName(name.c_str());
-}
-
 int GetCurveFromName(const char* name) {
   int nid = EC_curve_nist2nid(name);
   if (nid == NID_undef)
@@ -343,7 +339,7 @@ EcKeyPairGenConfig prepareEcKeyGenConfig(jsi::Runtime &rt,
 
   // curve name
   std::string curveName = args[1].asString(rt).utf8(rt);
-  config.curve_nid = GetCurveFromName(curveName);
+  config.curve_nid = GetCurveFromName(curveName.c_str());
 
   // encoding
   if (CheckIsInt32(args[2].asNumber())) {
@@ -413,7 +409,7 @@ std::pair<JSVariant, JSVariant> generateEcKeyPair(jsi::Runtime& runtime,
                                                   std::shared_ptr<EcKeyPairGenConfig> config)
 {
   // TODO: this is all copied from MGLRsa.cpp - template it up like Node
-  
+
   EVPKeyCtxPointer ctx = setup(config);
 
   if (!ctx) {

--- a/cpp/webcrypto/crypto_ec.cpp
+++ b/cpp/webcrypto/crypto_ec.cpp
@@ -10,7 +10,6 @@
 #include <openssl/ec.h>
 #include <string>
 #include <utility>
-#include <MGLJSIUtils.h>
 
 namespace margelo {
 namespace jsi = facebook::jsi;

--- a/cpp/webcrypto/crypto_ec.h
+++ b/cpp/webcrypto/crypto_ec.h
@@ -60,6 +60,22 @@ std::shared_ptr<KeyObjectData> ImportJWKEcKey(jsi::Runtime &rt,
 jsi::Value GetEcKeyDetail(jsi::Runtime &rt,
                           std::shared_ptr<KeyObjectData> key);
 
+struct EcKeyPairGenConfig {
+  PublicKeyEncodingConfig public_key_encoding;
+  PrivateKeyEncodingConfig private_key_encoding;
+  ManagedEVPPKey key;
+
+  int curve_nid;
+  int param_encoding;
+};
+
+EcKeyPairGenConfig prepareEcKeyGenConfig(jsi::Runtime& runtime,
+                                       const jsi::Value* arguments);
+
+std::pair<JSVariant, JSVariant> generateEcKeyPair(jsi::Runtime& runtime,
+                                                  std::shared_ptr<EcKeyPairGenConfig> config);
+
+
 } // namespace margelo
 
 #endif /* crypto_ec_hpp */

--- a/cpp/webcrypto/crypto_ec.h
+++ b/cpp/webcrypto/crypto_ec.h
@@ -15,9 +15,11 @@
 #ifdef ANDROID
 #include "Utils/MGLUtils.h"
 #include "webcrypto/MGLWebCrypto.h"
+#include "JSIUtils/MGLJSIUtils.h"
 #else
 #include "MGLUtils.h"
 #include "MGLWebCrypto.h"
+#include "MGLJSIUtils.h"
 #endif
 
 

--- a/cpp/webcrypto/crypto_ec.h
+++ b/cpp/webcrypto/crypto_ec.h
@@ -72,8 +72,8 @@ struct EcKeyPairGenConfig {
 EcKeyPairGenConfig prepareEcKeyGenConfig(jsi::Runtime& runtime,
                                        const jsi::Value* arguments);
 
-std::pair<JSVariant, JSVariant> generateEcKeyPair(jsi::Runtime& runtime,
-                                                  std::shared_ptr<EcKeyPairGenConfig> config);
+std::pair<jsi::Value, jsi::Value> generateEcKeyPair(jsi::Runtime& runtime,
+                                                    std::shared_ptr<EcKeyPairGenConfig> config);
 
 
 } // namespace margelo

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -320,7 +320,7 @@ PODS:
   - react-native-quick-base64 (2.1.2):
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
-  - react-native-quick-crypto (0.7.0-rc.5):
+  - react-native-quick-crypto (0.7.0-rc.6):
     - OpenSSL-Universal
     - RCT-Folly (= 2021.07.22.00)
     - React
@@ -437,7 +437,7 @@ PODS:
     - React-jsi (= 0.72.7)
     - React-logger (= 0.72.7)
     - React-perflogger (= 0.72.7)
-  - RNCCheckbox (0.5.16):
+  - RNCCheckbox (0.5.17):
     - BEMCheckBox (~> 1.4)
     - React-Core
   - RNScreens (3.27.0):
@@ -620,7 +620,7 @@ SPEC CHECKSUMS:
   React-jsinspector: 8baadae51f01d867c3921213a25ab78ab4fbcd91
   React-logger: 8edc785c47c8686c7962199a307015e2ce9a0e4f
   react-native-quick-base64: 61228d753294ae643294a75fece8e0e80b7558a6
-  react-native-quick-crypto: 419d628c781a5144fbed43d104fb1f314ecaeff4
+  react-native-quick-crypto: 0f1c9ae20bc06e10f0349887a9e3767ff683c5ac
   react-native-safe-area-context: 2cd91d532de12acdb0a9cbc8d43ac72a8e4c897c
   React-NativeModulesApple: b6868ee904013a7923128892ee4a032498a1024a
   React-perflogger: 31ea61077185eb1428baf60c0db6e2886f141a5a
@@ -639,7 +639,7 @@ SPEC CHECKSUMS:
   React-runtimescheduler: 7649c3b46c8dee1853691ecf60146a16ae59253c
   React-utils: 56838edeaaf651220d1e53cd0b8934fb8ce68415
   ReactCommon: 5f704096ccf7733b390f59043b6fa9cc180ee4f6
-  RNCCheckbox: 75255b03e604bbcc26411eb31c4cbe3e3865f538
+  RNCCheckbox: a3ca9978cb0846b981d28da4e9914bd437403d77
   RNScreens: 3c2d122f5e08c192e254c510b212306da97d2581
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   Yoga: 4c3aa327e4a6a23eeacd71f61c81df1bcdf677d5

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -320,7 +320,7 @@ PODS:
   - react-native-quick-base64 (2.1.2):
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
-  - react-native-quick-crypto (0.7.0-rc.4):
+  - react-native-quick-crypto (0.7.0-rc.5):
     - OpenSSL-Universal
     - RCT-Folly (= 2021.07.22.00)
     - React
@@ -620,7 +620,7 @@ SPEC CHECKSUMS:
   React-jsinspector: 8baadae51f01d867c3921213a25ab78ab4fbcd91
   React-logger: 8edc785c47c8686c7962199a307015e2ce9a0e4f
   react-native-quick-base64: 61228d753294ae643294a75fece8e0e80b7558a6
-  react-native-quick-crypto: 80bd167c74302d8495ab4c7ea2c9f55ee93522f2
+  react-native-quick-crypto: 419d628c781a5144fbed43d104fb1f314ecaeff4
   react-native-safe-area-context: 2cd91d532de12acdb0a9cbc8d43ac72a8e4c897c
   React-NativeModulesApple: b6868ee904013a7923128892ee4a032498a1024a
   React-perflogger: 31ea61077185eb1428baf60c0db6e2886f141a5a

--- a/example/package.json
+++ b/example/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@craftzdog/react-native-buffer": "^6.0.5",
-    "@react-native-community/checkbox": "^0.5.16",
+    "@react-native-community/checkbox": "^0.5.17",
     "@react-navigation/native": "^6.1.6",
     "@react-navigation/native-stack": "^6.9.12",
     "buffer": "^6.0.3",

--- a/example/src/hooks/useTestList.ts
+++ b/example/src/hooks/useTestList.ts
@@ -14,10 +14,11 @@ import '../testing/Tests/CipherTests/PublicCipherTests';
 import '../testing/Tests/CipherTests/GenerateKeyPairTests';
 import '../testing/Tests/ConstantsTests/ConstantsTests';
 import '../testing/Tests/SignTests/SignTests';
-import '../testing/Tests/webcryptoTests/import_export';
+import '../testing/Tests/SmokeTests/bundlerTests';
 import '../testing/Tests/webcryptoTests/deriveBits';
 import '../testing/Tests/webcryptoTests/digest';
-import '../testing/Tests/SmokeTests/bundlerTests';
+import '../testing/Tests/webcryptoTests/generateKey';
+import '../testing/Tests/webcryptoTests/import_export';
 
 export const useTestList = (): [
   Suites,

--- a/example/src/testing/Tests/webcryptoTests/generateKey.ts
+++ b/example/src/testing/Tests/webcryptoTests/generateKey.ts
@@ -1,0 +1,683 @@
+import { expect } from 'chai';
+// import type { Buffer } from '@craftzdog/react-native-buffer';
+import { describe, it } from '../../MochaRNAdapter';
+import crypto from 'react-native-quick-crypto';
+import { assertThrowsAsync } from '../util';
+import type {
+  AnyAlgorithm,
+  CryptoKey,
+  CryptoKeyPair,
+  KeyUsage,
+  NamedCurve,
+} from '../../../../../src/keys';
+
+const { subtle } = crypto;
+
+const allUsages: KeyUsage[] = [
+  'encrypt',
+  'decrypt',
+  'sign',
+  'verify',
+  'deriveBits',
+  'deriveKey',
+  'wrapKey',
+  'unwrapKey',
+];
+
+type Vector = {
+  algorithm?: Object;
+  result: string;
+  usages: KeyUsage[];
+};
+
+type Vectors = {
+  [key in string]: Vector;
+};
+
+const vectors: Vectors = {
+  // 'AES-CTR': {
+  //   algorithm: { length: 256 },
+  //   result: 'CryptoKey',
+  //   usages: ['encrypt', 'decrypt', 'wrapKey', 'unwrapKey'],
+  // },
+  // 'AES-CBC': {
+  //   algorithm: { length: 256 },
+  //   result: 'CryptoKey',
+  //   usages: ['encrypt', 'decrypt', 'wrapKey', 'unwrapKey'],
+  // },
+  // 'AES-GCM': {
+  //   algorithm: { length: 256 },
+  //   result: 'CryptoKey',
+  //   usages: ['encrypt', 'decrypt', 'wrapKey', 'unwrapKey'],
+  // },
+  // 'AES-KW': {
+  //   algorithm: { length: 256 },
+  //   result: 'CryptoKey',
+  //   usages: ['wrapKey', 'unwrapKey'],
+  // },
+  // 'HMAC': {
+  //   algorithm: { length: 256, hash: 'SHA-256' },
+  //   result: 'CryptoKey',
+  //   usages: ['sign', 'verify'],
+  // },
+  // 'RSASSA-PKCS1-v1_5': {
+  //   algorithm: {
+  //     modulusLength: 1024,
+  //     publicExponent: new Uint8Array([1, 0, 1]),
+  //     hash: 'SHA-256',
+  //   },
+  //   result: 'CryptoKeyPair',
+  //   usages: ['sign', 'verify'],
+  // },
+  // 'RSA-PSS': {
+  //   algorithm: {
+  //     modulusLength: 1024,
+  //     publicExponent: new Uint8Array([1, 0, 1]),
+  //     hash: 'SHA-256',
+  //   },
+  //   result: 'CryptoKeyPair',
+  //   usages: ['sign', 'verify'],
+  // },
+  // 'RSA-OAEP': {
+  //   algorithm: {
+  //     modulusLength: 1024,
+  //     publicExponent: new Uint8Array([1, 0, 1]),
+  //     hash: 'SHA-256',
+  //   },
+  //   result: 'CryptoKeyPair',
+  //   usages: ['encrypt', 'decrypt', 'wrapKey', 'unwrapKey'],
+  // },
+  ECDSA: {
+    algorithm: { namedCurve: 'P-521' },
+    result: 'CryptoKeyPair',
+    usages: ['sign', 'verify'],
+  },
+  ECDH: {
+    algorithm: { namedCurve: 'P-521' },
+    result: 'CryptoKeyPair',
+    usages: ['deriveKey', 'deriveBits'],
+  },
+  // 'Ed25519': {
+  //   result: 'CryptoKeyPair',
+  //   usages: ['sign', 'verify'],
+  // },
+  // 'Ed448': {
+  //   result: 'CryptoKeyPair',
+  //   usages: ['sign', 'verify'],
+  // },
+  // 'X25519': {
+  //   result: 'CryptoKeyPair',
+  //   usages: ['deriveKey', 'deriveBits'],
+  // },
+  // 'X448': {
+  //   result: 'CryptoKeyPair',
+  //   usages: ['deriveKey', 'deriveBits'],
+  // },
+};
+
+describe('subtle - generateKey', () => {
+  // Test invalid algorithms
+  {
+    async function testInvalidAlgorithm(algorithm: any) {
+      const algo = JSON.stringify(algorithm);
+      it(`invalid algo: ${algo}`, async () => {
+        await assertThrowsAsync(
+          async () =>
+            // @ts-expect-error
+            // The extractable and usages values are invalid here also,
+            // but the unrecognized algorithm name should be caught first.
+            await subtle.generateKey(algorithm, 7, []),
+          'Unrecognized algorithm name'
+        );
+      });
+    }
+
+    const invalidAlgoTests = [
+      'AES',
+      { name: 'AES' },
+      { name: 'AES-CMAC' },
+      { name: 'AES-CFB' },
+      { name: 'HMAC', hash: 'MD5' },
+      {
+        name: 'RSA',
+        hash: 'SHA-256',
+        modulusLength: 2048,
+        publicExponent: new Uint8Array([1, 0, 1]),
+      },
+      {
+        name: 'RSA-PSS',
+        hash: 'SHA',
+        modulusLength: 2048,
+        publicExponent: new Uint8Array([1, 0, 1]),
+      },
+      {
+        name: 'EC',
+        namedCurve: 'P521',
+      },
+    ];
+
+    invalidAlgoTests.map(testInvalidAlgorithm);
+  }
+
+  // Test bad usages
+  {
+    async function testBadUsage(name: string) {
+      it(`bad usages: ${name}`, async () => {
+        await assertThrowsAsync(
+          async () =>
+            await subtle.generateKey(
+              {
+                name: name as AnyAlgorithm,
+                ...vectors[name]?.algorithm,
+              },
+              true,
+              []
+            ),
+          'Usages cannot be empty'
+        );
+
+        // For CryptoKeyPair results the private key
+        // usages must not be empty.
+        // - ECDH(-like) algorithm key pairs only have private key usages
+        // - Signing algorithm key pairs may pass a non-empty array but
+        //   with only a public key usage
+        if (
+          vectors[name]?.result === 'CryptoKeyPair' &&
+          vectors[name]?.usages.includes('verify')
+        ) {
+          await assertThrowsAsync(
+            async () =>
+              await subtle.generateKey(
+                {
+                  name: name as AnyAlgorithm,
+                  ...vectors[name]?.algorithm,
+                },
+                true,
+                ['verify']
+              ),
+            'Usages cannot be empty'
+          );
+        }
+
+        const invalidUsages: KeyUsage[] = [];
+        allUsages.forEach((usage) => {
+          if (!vectors[name]?.usages.includes(usage)) {
+            invalidUsages.push(usage);
+          }
+        });
+        for (const invalidUsage of invalidUsages) {
+          await assertThrowsAsync(
+            async () =>
+              await subtle.generateKey(
+                {
+                  name: name as AnyAlgorithm,
+                  ...vectors[name]?.algorithm,
+                },
+                true,
+                [...(vectors[name]?.usages as KeyUsage[]), invalidUsage]
+              ),
+            'Unsupported key usage'
+          );
+        }
+      });
+    }
+
+    const badUsageTests = Object.keys(vectors);
+    badUsageTests.map(testBadUsage);
+  }
+
+  /*
+  // Test RSA key generation
+  {
+    async function test(
+      name,
+      modulusLength,
+      publicExponent,
+      hash,
+      privateUsages,
+      publicUsages = privateUsages
+    ) {
+      let usages = privateUsages;
+      if (publicUsages !== privateUsages) usages = usages.concat(publicUsages);
+      const { publicKey, privateKey } = await subtle.generateKey(
+        {
+          name,
+          modulusLength,
+          publicExponent,
+          hash,
+        },
+        true,
+        usages
+      );
+
+      assert(publicKey);
+      assert(privateKey);
+      assert(isCryptoKey(publicKey));
+      assert(isCryptoKey(privateKey));
+
+      assert(publicKey instanceof CryptoKey);
+      assert(privateKey instanceof CryptoKey);
+
+      assert.strictEqual(publicKey.type, 'public');
+      assert.strictEqual(privateKey.type, 'private');
+      assert.strictEqual(publicKey.toString(), '[object CryptoKey]');
+      assert.strictEqual(privateKey.toString(), '[object CryptoKey]');
+      assert.strictEqual(publicKey.extractable, true);
+      assert.strictEqual(privateKey.extractable, true);
+      assert.deepStrictEqual(publicKey.usages, publicUsages);
+      assert.deepStrictEqual(privateKey.usages, privateUsages);
+      assert.strictEqual(publicKey.algorithm.name, name);
+      assert.strictEqual(publicKey.algorithm.modulusLength, modulusLength);
+      assert.deepStrictEqual(publicKey.algorithm.publicExponent, publicExponent);
+      assert.strictEqual(
+        KeyObject.from(publicKey).asymmetricKeyDetails.publicExponent,
+        bigIntArrayToUnsignedBigInt(publicExponent)
+      );
+      assert.strictEqual(publicKey.algorithm.hash.name, hash);
+      assert.strictEqual(privateKey.algorithm.name, name);
+      assert.strictEqual(privateKey.algorithm.modulusLength, modulusLength);
+      assert.deepStrictEqual(privateKey.algorithm.publicExponent, publicExponent);
+      assert.strictEqual(
+        KeyObject.from(privateKey).asymmetricKeyDetails.publicExponent,
+        bigIntArrayToUnsignedBigInt(publicExponent)
+      );
+      assert.strictEqual(privateKey.algorithm.hash.name, hash);
+
+      // Missing parameters
+      await assert.rejects(
+        subtle.generateKey({ name, publicExponent, hash }, true, usages),
+        {
+          code: 'ERR_MISSING_OPTION',
+        }
+      );
+
+      await assert.rejects(
+        subtle.generateKey({ name, modulusLength, hash }, true, usages),
+        {
+          code: 'ERR_MISSING_OPTION',
+        }
+      );
+
+      await assert.rejects(
+        subtle.generateKey({ name, modulusLength }, true, usages),
+        {
+          code: 'ERR_MISSING_OPTION',
+        }
+      );
+
+      await Promise.all(
+        [{}].map((modulusLength) => {
+          return assert.rejects(
+            subtle.generateKey(
+              {
+                name,
+                modulusLength,
+                publicExponent,
+                hash,
+              },
+              true,
+              usages
+            ),
+            {
+              code: 'ERR_INVALID_ARG_TYPE',
+            }
+          );
+        })
+      );
+
+      await Promise.all(
+        ['', true, {}, 1, [], new Uint32Array(2)].map((publicExponent) => {
+          return assert.rejects(
+            subtle.generateKey(
+              { name, modulusLength, publicExponent, hash },
+              true,
+              usages
+            ),
+            { code: 'ERR_INVALID_ARG_TYPE' }
+          );
+        })
+      );
+
+      await Promise.all(
+        [true, 1].map((hash) => {
+          return assert.rejects(
+            subtle.generateKey(
+              {
+                name,
+                modulusLength,
+                publicExponent,
+                hash,
+              },
+              true,
+              usages
+            ),
+            {
+              message: /Unrecognized algorithm name/,
+              name: 'NotSupportedError',
+            }
+          );
+        })
+      );
+
+      await Promise.all(
+        ['', {}, 1, false].map((usages) => {
+          return assert.rejects(
+            subtle.generateKey(
+              {
+                name,
+                modulusLength,
+                publicExponent,
+                hash,
+              },
+              true,
+              usages
+            ),
+            {
+              code: 'ERR_INVALID_ARG_TYPE',
+            }
+          );
+        })
+      );
+
+      await Promise.all(
+        [[1], [1, 0, 0]].map((publicExponent) => {
+          return assert.rejects(
+            subtle.generateKey(
+              {
+                name,
+                modulusLength,
+                publicExponent: new Uint8Array(publicExponent),
+                hash,
+              },
+              true,
+              usages
+            ),
+            {
+              name: 'OperationError',
+            }
+          );
+        })
+      );
+    }
+
+    const kTests = [
+      [
+        'RSASSA-PKCS1-v1_5',
+        1024,
+        Buffer.from([1, 0, 1]),
+        'SHA-256',
+        ['sign'],
+        ['verify'],
+      ],
+      ['RSA-PSS', 2048, Buffer.from([1, 0, 1]), 'SHA-512', ['sign'], ['verify']],
+      [
+        'RSA-OAEP',
+        1024,
+        Buffer.from([3]),
+        'SHA-384',
+        ['decrypt', 'unwrapKey'],
+        ['encrypt', 'wrapKey'],
+      ],
+    ];
+
+    const tests = kTests.map((args) => test(...args));
+
+    Promise.all(tests).then(common.mustCall());
+  }
+  */
+
+  type CryptoKeysInPair = {
+    publicKey: CryptoKey;
+    privateKey: CryptoKey;
+  };
+
+  // Test EC Key Generation
+  {
+    async function testECKeyGen(
+      name: AnyAlgorithm,
+      namedCurve: NamedCurve,
+      privateUsages: KeyUsage[],
+      publicUsages: KeyUsage[] = privateUsages
+    ) {
+      it(`EC keygen: ${name} ${namedCurve} ${privateUsages} ${publicUsages}`, async () => {
+        let usages = privateUsages;
+        if (publicUsages !== privateUsages) {
+          usages = usages.concat(publicUsages);
+        }
+
+        const pair = await subtle.generateKey(
+          {
+            name,
+            namedCurve,
+          },
+          true,
+          usages
+        );
+        const { publicKey, privateKey }: CryptoKeysInPair =
+          pair as CryptoKeyPair;
+
+        expect(publicKey).is.not.undefined;
+        expect(privateKey).is.not.undefined;
+        // expect(isCryptoKey(publicKey));
+        // expect(isCryptoKey(privateKey));
+
+        // expect(publicKey.type).to.equal('public');
+        // expect(privateKey.type).to.equal('private');
+        // expect(publicKey.toString()).to.equal('[object CryptoKey]');
+        // expect(privateKey.toString()).to.equal('[object CryptoKey]');
+        expect(publicKey.keyExtractable).to.equal(true);
+        expect(privateKey.keyExtractable).to.equal(true);
+        expect(publicKey.keyUsages).to.deep.equal(publicUsages);
+        expect(privateKey.keyUsages).to.deep.equal(privateUsages);
+        expect(publicKey.algorithm.name, name);
+        expect(privateKey.algorithm.name, name);
+        expect(publicKey.algorithm.namedCurve, namedCurve);
+        expect(privateKey.algorithm.namedCurve, namedCurve);
+
+        // Invalid parameters
+        [1, true, {}, [], null].forEach(async (curve) => {
+          await assertThrowsAsync(
+            async () =>
+              await subtle.generateKey(
+                // @ts-expect-error
+                { name, namedCurve: curve },
+                true,
+                privateUsages
+              ),
+            'NotSupportedError'
+          );
+        });
+        await assertThrowsAsync(
+          async () =>
+            subtle.generateKey(
+              { name, namedCurve: undefined },
+              true,
+              privateUsages
+            ),
+          "Unrecognized namedCurve 'undefined'"
+        );
+      });
+    }
+
+    testECKeyGen('ECDSA', 'P-384', ['sign'], ['verify']);
+    testECKeyGen('ECDSA', 'P-521', ['sign'], ['verify']);
+    testECKeyGen('ECDH', 'P-384', ['deriveKey', 'deriveBits'], []);
+    testECKeyGen('ECDH', 'P-521', ['deriveKey', 'deriveBits'], []);
+  }
+  /*
+  // Test AES Key Generation
+  {
+    async function test(name, length, usages) {
+      const key = await subtle.generateKey(
+        {
+          name,
+          length,
+        },
+        true,
+        usages
+      );
+
+      assert(key);
+      assert(isCryptoKey(key));
+
+      assert.strictEqual(key.type, 'secret');
+      assert.strictEqual(key.toString(), '[object CryptoKey]');
+      assert.strictEqual(key.extractable, true);
+      assert.deepStrictEqual(key.usages, usages);
+      assert.strictEqual(key.algorithm.name, name);
+      assert.strictEqual(key.algorithm.length, length);
+
+      // Invalid parameters
+      [1, 100, 257, '', false, null].forEach(async (length) => {
+        await assert.rejects(subtle.generateKey({ name, length }, true, usages), {
+          name: 'OperationError',
+        });
+      });
+
+      await assert.rejects(
+        subtle.generateKey({ name, length: undefined }, true, usages),
+        {
+          name: 'TypeError',
+          code: 'ERR_MISSING_OPTION',
+        }
+      );
+    }
+
+    const kTests = [
+      ['AES-CTR', 128, ['encrypt', 'decrypt', 'wrapKey']],
+      ['AES-CTR', 256, ['encrypt', 'decrypt', 'unwrapKey']],
+      ['AES-CBC', 128, ['encrypt', 'decrypt']],
+      ['AES-CBC', 256, ['encrypt', 'decrypt']],
+      ['AES-GCM', 128, ['encrypt', 'decrypt']],
+      ['AES-GCM', 256, ['encrypt', 'decrypt']],
+      ['AES-KW', 128, ['wrapKey', 'unwrapKey']],
+      ['AES-KW', 256, ['wrapKey', 'unwrapKey']],
+    ];
+
+    const tests = Promise.all(kTests.map((args) => test(...args)));
+
+    tests.then(common.mustCall());
+  }
+
+  // Test HMAC Key Generation
+  {
+    async function test(length, hash, usages) {
+      const key = await subtle.generateKey(
+        {
+          name: 'HMAC',
+          length,
+          hash,
+        },
+        true,
+        usages
+      );
+
+      if (length === undefined) {
+        switch (hash) {
+          case 'SHA-1':
+            length = 512;
+            break;
+          case 'SHA-256':
+            length = 512;
+            break;
+          case 'SHA-384':
+            length = 1024;
+            break;
+          case 'SHA-512':
+            length = 1024;
+            break;
+        }
+      }
+
+      assert(key);
+      assert(isCryptoKey(key));
+
+      assert.strictEqual(key.type, 'secret');
+      assert.strictEqual(key.toString(), '[object CryptoKey]');
+      assert.strictEqual(key.extractable, true);
+      assert.deepStrictEqual(key.usages, usages);
+      assert.strictEqual(key.algorithm.name, 'HMAC');
+      assert.strictEqual(key.algorithm.length, length);
+      assert.strictEqual(key.algorithm.hash.name, hash);
+
+      [1, false, null].forEach(async (hash) => {
+        await assert.rejects(
+          subtle.generateKey({ name: 'HMAC', length, hash }, true, usages),
+          {
+            message: /Unrecognized algorithm name/,
+            name: 'NotSupportedError',
+          }
+        );
+      });
+    }
+
+    const kTests = [
+      [undefined, 'SHA-1', ['sign', 'verify']],
+      [undefined, 'SHA-256', ['sign', 'verify']],
+      [undefined, 'SHA-384', ['sign', 'verify']],
+      [undefined, 'SHA-512', ['sign', 'verify']],
+      [128, 'SHA-256', ['sign', 'verify']],
+      [1024, 'SHA-512', ['sign', 'verify']],
+    ];
+
+    const tests = Promise.all(kTests.map((args) => test(...args)));
+
+    tests.then(common.mustCall());
+  }
+
+  // End user code cannot create CryptoKey directly
+  assert.throws(() => new CryptoKey(), { code: 'ERR_ILLEGAL_CONSTRUCTOR' });
+
+  {
+    const buffer = Buffer.from('Hello World');
+    const keyObject = createSecretKey(buffer);
+    assert(!isCryptoKey(buffer));
+    assert(!isCryptoKey(keyObject));
+  }
+
+  // Test OKP Key Generation
+  {
+    async function test(name, privateUsages, publicUsages = privateUsages) {
+      let usages = privateUsages;
+      if (publicUsages !== privateUsages) usages = usages.concat(publicUsages);
+
+      const { publicKey, privateKey } = await subtle.generateKey(
+        {
+          name,
+        },
+        true,
+        usages
+      );
+
+      assert(publicKey);
+      assert(privateKey);
+      assert(isCryptoKey(publicKey));
+      assert(isCryptoKey(privateKey));
+
+      assert.strictEqual(publicKey.type, 'public');
+      assert.strictEqual(privateKey.type, 'private');
+      assert.strictEqual(publicKey.toString(), '[object CryptoKey]');
+      assert.strictEqual(privateKey.toString(), '[object CryptoKey]');
+      assert.strictEqual(publicKey.extractable, true);
+      assert.strictEqual(privateKey.extractable, true);
+      assert.deepStrictEqual(publicKey.usages, publicUsages);
+      assert.deepStrictEqual(privateKey.usages, privateUsages);
+      assert.strictEqual(publicKey.algorithm.name, name);
+      assert.strictEqual(privateKey.algorithm.name, name);
+    }
+
+    const kTests = [
+      ['Ed25519', ['sign'], ['verify']],
+      ['Ed448', ['sign'], ['verify']],
+      ['X25519', ['deriveKey', 'deriveBits'], []],
+      ['X448', ['deriveKey', 'deriveBits'], []],
+    ];
+
+    const tests = kTests.map((args) => test(...args));
+
+    // Test bad parameters
+
+    Promise.all(tests).then(common.mustCall());
+  }
+  */
+});

--- a/example/src/testing/Tests/webcryptoTests/generateKey.ts
+++ b/example/src/testing/Tests/webcryptoTests/generateKey.ts
@@ -10,6 +10,7 @@ import type {
   KeyUsage,
   NamedCurve,
 } from '../../../../../src/keys';
+import { isCryptoKey } from '../../../../../src/keys';
 
 const { subtle } = crypto;
 
@@ -458,13 +459,10 @@ describe('subtle - generateKey', () => {
 
         expect(publicKey).is.not.undefined;
         expect(privateKey).is.not.undefined;
-        // expect(isCryptoKey(publicKey));
-        // expect(isCryptoKey(privateKey));
-
-        // expect(publicKey.type).to.equal('public');
-        // expect(privateKey.type).to.equal('private');
-        // expect(publicKey.toString()).to.equal('[object CryptoKey]');
-        // expect(privateKey.toString()).to.equal('[object CryptoKey]');
+        expect(isCryptoKey(publicKey));
+        expect(isCryptoKey(privateKey));
+        expect(publicKey.type).to.equal('public');
+        expect(privateKey.type).to.equal('private');
         expect(publicKey.keyExtractable).to.equal(true);
         expect(privateKey.keyExtractable).to.equal(true);
         expect(publicKey.keyUsages).to.deep.equal(publicUsages);

--- a/example/src/testing/Tests/webcryptoTests/import_export.ts
+++ b/example/src/testing/Tests/webcryptoTests/import_export.ts
@@ -285,12 +285,12 @@ describe('subtle - importKey / exportKey', () => {
 
     // test random Uint8Array
     const random = crypto.getRandomValues(new Uint8Array(32));
-    test(random, 'random');
+    test(random as Uint8Array, 'random');
 
     // test while ensuring at least one of the elements is zero
     const withZero = crypto.getRandomValues(new Uint8Array(32));
     withZero[4] = 0;
-    test(withZero, 'with zero');
+    test(withZero as Uint8Array, 'with zero');
   }
 
   // from https://gist.github.com/pedrouid/b4056fd1f754918ddae86b32cf7d803e#aes-gcm---importkey

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -1347,10 +1347,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@react-native-community/checkbox@^0.5.16":
-  version "0.5.16"
-  resolved "https://registry.yarnpkg.com/@react-native-community/checkbox/-/checkbox-0.5.16.tgz#3265260e5fd961a4f032d0c088bbfbdfa96ee44e"
-  integrity sha512-j4fmWe77EAayGnKJ52BljlN8apLT3xjxG/pJOA6HZ4ew63FiXmnY7VtxTzmvDKgSPrETdQc2lmx5mdXTAufJnw==
+"@react-native-community/checkbox@^0.5.17":
+  version "0.5.17"
+  resolved "https://registry.yarnpkg.com/@react-native-community/checkbox/-/checkbox-0.5.17.tgz#80dd335ca5c61ac2ca4525a21d8fef3f7a021ef7"
+  integrity sha512-ZZx/eOH3SIxBg+hvA2zRd7lX5zPQEWcZU8C8Dn7WLdpJkiTkPmIUDFHWrmzxCnwZcyoD+BIt6gUZPKGGb9WmeQ==
 
 "@react-native-community/cli-clean@11.3.10":
   version "11.3.10"

--- a/implementation-coverage.md
+++ b/implementation-coverage.md
@@ -148,18 +148,18 @@ This document attempts to describe the implementation status of Crypto APIs/Inte
 🚧 Details below still a work in progress 🚧
 
 ## `crypto.generateKey`
-| type           | Status |
-| ---------      | :----: |
+| type       | Status |
+| ---------  | :----: |
 | `aes`      | ❌ |
 | `hmac`     | ❌ |
 
 ## `crypto.generateKeyPair`
-| type           | Status |
-| ---------      | :----: |
+| type      | Status |
+| --------- | :----: |
 | `rsa`     | ✅ |
 | `rsa-pss` | ✅ |
 | `dsa`     | ❌ |
-| `ec`      | ❌ |
+| `ec`      | ✅ |
 | `ed25519` | ❌ |
 | `ed448`   | ❌ |
 | `x25519`  | ❌ |
@@ -167,12 +167,12 @@ This document attempts to describe the implementation status of Crypto APIs/Inte
 | `dh`      | ❌ |
 
 ## `crypto.generateKeyPairSync`
-| type           | Status |
-| ---------      | :----: |
+| type      | Status |
+| --------- | :----: |
 | `rsa`     | ✅ |
 | `rsa-pss` | ✅ |
 | `dsa`     | ❌ |
-| `ec`      | ❌ |
+| `ec`      | ✅ |
 | `ed25519` | ❌ |
 | `ed448`   | ❌ |
 | `x25519`  | ❌ |
@@ -180,8 +180,8 @@ This document attempts to describe the implementation status of Crypto APIs/Inte
 | `dh`      | ❌ |
 
 ## `crypto.generateKeySync`
-| type           | Status |
-| ---------      | :----: |
+| type       | Status |
+| ---------  | :----: |
 | `aes`      | ❌ |
 | `hmac`     | ❌ |
 
@@ -212,7 +212,7 @@ This document attempts to describe the implementation status of Crypto APIs/Inte
   * ✅ `subtle.digest(algorithm, data)`
   * ❌ `subtle.encrypt(algorithm, key, data)`
   * 🚧 `subtle.exportKey(format, key)`
-  * ❌ `subtle.generateKey(algorithm, extractable, keyUsages)`
+  * 🚧 `subtle.generateKey(algorithm, extractable, keyUsages)`
   * 🚧 `subtle.importKey(format, keyData, algorithm, extractable, keyUsages)`
   * ❌ `subtle.sign(algorithm, key, data)`
   * ❌ `subtle.unwrapKey(format, wrappedKey, unwrappingKey, unwrapAlgo, unwrappedKeyAlgo, extractable, keyUsages)`
@@ -291,21 +291,21 @@ This document attempts to describe the implementation status of Crypto APIs/Inte
 | `RSASSA-PKCS1-v1_5` |  |
 | `RSA-PSS`           |  |
 | `RSA-OAEP`          |  |
-| `ECDSA`             |  |
-| `Ed25519`           |  |
+| `ECDSA`             | ✅ |
+| `Ed25519`           | ✅ |
 | `Ed448`             |  |
 | `ECDH`              |  |
 | `X25519`            |  |
 | `X448`              |  |
 
 ### `CryptoKey` algorithms
-| Algorithm    | Status |
-| ---------    | :----: |
-| `HMAC`       |  |
-| `AES-CTR`    |  |
-| `AES-CBC`    |  |
-| `AES-GCM`    |  |
-| `AES-KW`     |  |
+| Algorithm  | Status |
+| ---------  | :----: |
+| `HMAC`     |  |
+| `AES-CTR`  |  |
+| `AES-CBC`  |  |
+| `AES-GCM`  |  |
+| `AES-KW`   |  |
 
 ## `subtle.importKey`
 | Key Type            | `spki` | `pkcs8` | `jwk` | `raw` |

--- a/implementation-coverage.md
+++ b/implementation-coverage.md
@@ -109,8 +109,8 @@ This document attempts to describe the implementation status of Crypto APIs/Inte
   * ❌ `crypto.diffieHellman(options)`
   * ❌ `crypto.hash(algorithm, data[, outputEncoding])`
   * ❌ `crypto.generateKey(type, options, callback)`
-  * ✅ `crypto.generateKeyPair(type, options, callback)`
-  * ✅ `crypto.generateKeyPairSync(type, options)`
+  * 🚧 `crypto.generateKeyPair(type, options, callback)`
+  * 🚧 `crypto.generateKeyPairSync(type, options)`
   * ❌ `crypto.generateKeySync(type, options)`
   * ❌ `crypto.generatePrime(size[, options[, callback]])`
   * ❌ `crypto.generatePrimeSync(size[, options])`
@@ -145,6 +145,47 @@ This document attempts to describe the implementation status of Crypto APIs/Inte
   * ❌ `crypto.verify(algorithm, data, key, signature[, callback])`
   * 🚧 `crypto.webcrypto` (see below)
 
+🚧 Details below still a work in progress 🚧
+
+## `crypto.generateKey`
+| type           | Status |
+| ---------      | :----: |
+| `aes`      | ❌ |
+| `hmac`     | ❌ |
+
+## `crypto.generateKeyPair`
+| type           | Status |
+| ---------      | :----: |
+| `rsa`     | ✅ |
+| `rsa-pss` | ✅ |
+| `dsa`     | ❌ |
+| `ec`      | ❌ |
+| `ed25519` | ❌ |
+| `ed448`   | ❌ |
+| `x25519`  | ❌ |
+| `x448`    | ❌ |
+| `dh`      | ❌ |
+
+## `crypto.generateKeyPairSync`
+| type           | Status |
+| ---------      | :----: |
+| `rsa`     | ✅ |
+| `rsa-pss` | ✅ |
+| `dsa`     | ❌ |
+| `ec`      | ❌ |
+| `ed25519` | ❌ |
+| `ed448`   | ❌ |
+| `x25519`  | ❌ |
+| `x448`    | ❌ |
+| `dh`      | ❌ |
+
+## `crypto.generateKeySync`
+| type           | Status |
+| ---------      | :----: |
+| `aes`      | ❌ |
+| `hmac`     | ❌ |
+
+
 # `WebCrypto`
 
 * 🚧 Class: `Crypto`
@@ -178,7 +219,7 @@ This document attempts to describe the implementation status of Crypto APIs/Inte
   * ❌ `subtle.verify(algorithm, key, signature, data)`
   * ❌ `subtle.wrapKey(format, key, wrappingKey, wrapAlgo)`
 
-## `encrypt`
+## `subtle.decrypt`
 | Algorithm  | Status |
 | ---------  | :----: |
 | `RSA-OAEP` |  |
@@ -186,35 +227,25 @@ This document attempts to describe the implementation status of Crypto APIs/Inte
 | `AES-CBC`  |  |
 | `AES-GCM`  |  |
 
-## `decrypt`
+## `subtle.deriveBits`
 | Algorithm  | Status |
 | ---------  | :----: |
-| `RSA-OAEP` |  |
-| `AES-CTR`  |  |
-| `AES-CBC`  |  |
-| `AES-GCM`  |  |
+| `ECDH`     |  |
+| `X25519`   |  |
+| `X448`     |  |
+| `HKDF`     |  |
+| `PBKDF2`   | ✅ |
 
-## `sign`
-| Algorithm           | Status |
-| ---------           | :----: |
-| `RSASSA-PKCS1-v1_5` |  |
-| `RSA-PSS`           |  |
-| `ECDSA`             |  |
-| `Ed25519`           |  |
-| `Ed448`             |  |
-| `HMAC`              |  |
+## `subtle.deriveKey`
+| Algorithm  | Status |
+| ---------  | :----: |
+| `ECDH`     |  |
+| `X25519`   |  |
+| `X448`     |  |
+| `HKDF`     |  |
+| `PBKDF2`   |  |
 
-## `verify`
-| Algorithm           | Status |
-| ---------           | :----: |
-| `RSASSA-PKCS1-v1_5` |  |
-| `RSA-PSS`           |  |
-| `ECDSA`             |  |
-| `Ed25519`           |  |
-| `Ed448`             |  |
-| `HMAC`              |  |
-
-## `digest`
+## `subtle.digest`
 | Algorithm  | Status |
 | ---------  | :----: |
 | `SHA-1`    | ✅ |
@@ -222,7 +253,37 @@ This document attempts to describe the implementation status of Crypto APIs/Inte
 | `SHA-384`  | ✅ |
 | `SHA-512`  | ✅ |
 
-## `generateKey`
+## `subtle.encrypt`
+| Algorithm  | Status |
+| ---------  | :----: |
+| `RSA-OAEP` |  |
+| `AES-CTR`  |  |
+| `AES-CBC`  |  |
+| `AES-GCM`  |  |
+
+## `subtle.exportKey`
+| Key Type            | `spki` | `pkcs8` | `jwk` | `raw` |
+| ------------------- | :----: | :-----: | :---: | :---: |
+| `AES-CBC`           |   |   | ✅ | ✅ |
+| `AES-CTR`           |   |   | ✅ | ✅ |
+| `AES-GCM`           |   |   | ✅ | ✅ |
+| `AES-KW`            |   |   | ✅ | ✅ |
+| `ECDH`              | ✅ | ❌ | ✅ | ✅ |
+| `ECDSA`             | ✅ | ❌ | ✅ | ✅ |
+| `Ed25519`           | ❌ | ❌ | ❌ | ❌ |
+| `Ed448`             | ❌ | ❌ | ❌ | ❌ |
+| `HDKF`              |   |   |   |   |
+| `HMAC`              |   |   | ❌ | ❌ |
+| `PBKDF2`            |   |   |   |   |
+| `RSA-OAEP`          | ❌ | ❌ | ✅ |   |
+| `RSA-PSS`           | ❌ | ❌ | ✅ |   |
+| `RSASSA-PKCS1-v1_5` | ❌ | ❌ | ✅ |   |
+
+* ` ` - not implemented in Node
+* ❌ - implemented in Node, not RNQC
+* ✅ - implemented in Node and RNQC
+
+## `subtle.generateKey`
 
 ### `CryptoKeyPair` algorithms
 | Algorithm           | Status |
@@ -246,25 +307,7 @@ This document attempts to describe the implementation status of Crypto APIs/Inte
 | `AES-GCM`    |  |
 | `AES-KW`     |  |
 
-## `deriveKey`
-| Algorithm  | Status |
-| ---------  | :----: |
-| `ECDH`     |  |
-| `X25519`   |  |
-| `X448`     |  |
-| `HKDF`     |  |
-| `PBKDF2`   |  |
-
-## `deriveBits`
-| Algorithm  | Status |
-| ---------  | :----: |
-| `ECDH`     |  |
-| `X25519`   |  |
-| `X448`     |  |
-| `HKDF`     |  |
-| `PBKDF2`   | ✅ |
-
-## `importKey`
+## `subtle.importKey`
 | Key Type            | `spki` | `pkcs8` | `jwk` | `raw` |
 | ------------------- | :----: | :-----: | :---: | :---: |
 | `AES-CBC`           |   |   | ✅ | ✅ |
@@ -288,40 +331,17 @@ This document attempts to describe the implementation status of Crypto APIs/Inte
 * ❌ - implemented in Node, not RNQC
 * ✅ - implemented in Node and RNQC
 
-## `exportKey`
-| Key Type            | `spki` | `pkcs8` | `jwk` | `raw` |
-| ------------------- | :----: | :-----: | :---: | :---: |
-| `AES-CBC`           |   |   | ✅ | ✅ |
-| `AES-CTR`           |   |   | ✅ | ✅ |
-| `AES-GCM`           |   |   | ✅ | ✅ |
-| `AES-KW`            |   |   | ✅ | ✅ |
-| `ECDH`              | ✅ | ❌ | ✅ | ✅ |
-| `ECDSA`             | ✅ | ❌ | ✅ | ✅ |
-| `Ed25519`           | ❌ | ❌ | ❌ | ❌ |
-| `Ed448`             | ❌ | ❌ | ❌ | ❌ |
-| `HDKF`              |   |   |   |   |
-| `HMAC`              |   |   | ❌ | ❌ |
-| `PBKDF2`            |   |   |   |   |
-| `RSA-OAEP`          | ❌ | ❌ | ✅ |   |
-| `RSA-PSS`           | ❌ | ❌ | ✅ |   |
-| `RSASSA-PKCS1-v1_5` | ❌ | ❌ | ✅ |   |
+## `subtle.sign`
+| Algorithm           | Status |
+| ---------           | :----: |
+| `RSASSA-PKCS1-v1_5` |  |
+| `RSA-PSS`           |  |
+| `ECDSA`             |  |
+| `Ed25519`           |  |
+| `Ed448`             |  |
+| `HMAC`              |  |
 
-* ` ` - not implemented in Node
-* ❌ - implemented in Node, not RNQC
-* ✅ - implemented in Node and RNQC
-
-## `wrapKey`
-
-### wrapping algorithms
-| Algorithm  | Status |
-| ---------  | :----: |
-| `RSA-OAEP` |  |
-| `AES-CTR`  |  |
-| `AES-CBC`  |  |
-| `AES-GCM`  |  |
-| `AES-KW`   |  |
-
-## `unwrapKey`
+## `subtle.unwrapKey`
 
 ### wrapping algorithms
 | Algorithm  | Status |
@@ -349,3 +369,24 @@ This document attempts to describe the implementation status of Crypto APIs/Inte
 | `AES-CBC`           |  |
 | `AES-GCM`           |  |
 | `AES-KW`            |  |
+
+## `subtle.verify`
+| Algorithm           | Status |
+| ---------           | :----: |
+| `RSASSA-PKCS1-v1_5` |  |
+| `RSA-PSS`           |  |
+| `ECDSA`             |  |
+| `Ed25519`           |  |
+| `Ed448`             |  |
+| `HMAC`              |  |
+
+## `subtle.wrapKey`
+
+### wrapping algorithms
+| Algorithm  | Status |
+| ---------  | :----: |
+| `RSA-OAEP` |  |
+| `AES-CTR`  |  |
+| `AES-CBC`  |  |
+| `AES-GCM`  |  |
+| `AES-KW`   |  |

--- a/package.json
+++ b/package.json
@@ -173,5 +173,6 @@
     "readable-stream": "^4.5.2",
     "string_decoder": "^1.3.0",
     "util": "^0.12.5"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/Cipher.ts
+++ b/src/Cipher.ts
@@ -758,11 +758,12 @@ function internalGenerateKeyPair(
     default:
     // Fall through
   }
-  throw new Error(`
-    Invalid Argument options: '${type}' scheme not supported for generateKey().
-    Currently not all encryption methods are supported in quick-crypto.  Check
-    implementation_coverage.md for status.
-  `);
+  const err = new Error(`
+      Invalid Argument options: '${type}' scheme not supported for generateKey().
+      Currently not all encryption methods are supported in quick-crypto.  Check
+      implementation_coverage.md for status.
+    `);
+  return [err, undefined, undefined];
 }
 
 export const generateKeyPair = async (

--- a/src/Cipher.ts
+++ b/src/Cipher.ts
@@ -14,7 +14,7 @@ import {
   validateInt32,
   type BinaryLikeNode,
 } from './Utils';
-import { type InternalCipher, RSAKeyVariant } from './NativeQuickCrypto/Cipher';
+import { type InternalCipher, KeyVariant } from './NativeQuickCrypto/Cipher';
 import type {
   CipherCCMOptions,
   CipherCCMTypes,
@@ -542,8 +542,8 @@ function internalGenerateKeyPair(
 
       if (type === 'rsa') {
         if (isAsync) {
-          NativeQuickCrypto.generateKeyPairRSA(
-            RSAKeyVariant.kKeyVariantRSA_SSA_PKCS1_v1_5,
+          NativeQuickCrypto.generateKeyPair(
+            KeyVariant.RSA_SSA_PKCS1_v1_5,
             modulusLength as number,
             publicExponent,
             ...encoding
@@ -562,8 +562,8 @@ function internalGenerateKeyPair(
             });
         } else {
           let [err, publicKey, privateKey] =
-            NativeQuickCrypto.generateKeyPairSyncRSA(
-              RSAKeyVariant.kKeyVariantRSA_SSA_PKCS1_v1_5,
+            NativeQuickCrypto.generateKeyPairSync(
+              KeyVariant.RSA_SSA_PKCS1_v1_5,
               modulusLength as number,
               publicExponent,
               ...encoding
@@ -615,8 +615,8 @@ function internalGenerateKeyPair(
         }
       }
 
-      return NativeQuickCrypto.generateKeyPairSyncRSA(
-        RSAKeyVariant.kKeyVariantRSA_PSS,
+      return NativeQuickCrypto.generateKeyPairSync(
+        KeyVariant.RSA_PSS,
         modulusLength as number,
         publicExponent,
         hashAlgorithm || hash,
@@ -658,7 +658,8 @@ function internalGenerateKeyPair(
         );
 
       if (isAsync) {
-        NativeQuickCrypto.generateKeyPairEC(
+        NativeQuickCrypto.generateKeyPair(
+          KeyVariant.EC,
           namedCurve as NamedCurve,
           paramEncodingFlag,
           ...encoding
@@ -677,7 +678,8 @@ function internalGenerateKeyPair(
           });
       } else {
         let [err, publicKey, privateKey] =
-          NativeQuickCrypto.generateKeyPairSyncEC(
+          NativeQuickCrypto.generateKeyPairSync(
+            KeyVariant.EC,
             namedCurve as NamedCurve,
             paramEncodingFlag,
             ...encoding

--- a/src/NativeQuickCrypto/Cipher.ts
+++ b/src/NativeQuickCrypto/Cipher.ts
@@ -1,3 +1,4 @@
+import type { GenerateKeyPairReturn } from '../Cipher';
 import type { BinaryLike } from '../Utils';
 import type { Buffer } from '@craftzdog/react-native-buffer';
 
@@ -61,9 +62,9 @@ export type PrivateDecryptMethod = (
 export type GenerateKeyPairMethod = (
   keyVariant: KeyVariant,
   ...rest: any[]
-) => Promise<[error: unknown, publicBuffer: any, privateBuffer: any]>;
+) => Promise<GenerateKeyPairReturn>;
 
 export type GenerateKeyPairSyncMethod = (
   keyVariant: KeyVariant,
   ...rest: any[]
-) => [error: unknown, publicBuffer: any, privateBuffer: any];
+) => GenerateKeyPairReturn;

--- a/src/NativeQuickCrypto/Cipher.ts
+++ b/src/NativeQuickCrypto/Cipher.ts
@@ -1,5 +1,7 @@
 import type { BinaryLike } from '../Utils';
 import type { Buffer } from '@craftzdog/react-native-buffer';
+import type { NamedCurve } from '../keys';
+import type { ECCurve } from '../Cipher';
 
 // TODO(osp) on node this is defined on the native side
 // Need to do the same so that values are always in sync
@@ -55,16 +57,28 @@ export type PrivateDecryptMethod = (
   oaepLabel: any
 ) => Buffer;
 
-export type GenerateKeyPairMethod = (
+export type RSAGenerateKeyPairMethod = (
   keyVariant: RSAKeyVariant,
   modulusLength: number,
   publicExponent: number,
   ...rest: any[]
 ) => Promise<[error: unknown, publicBuffer: any, privateBuffer: any]>;
 
-export type GenerateKeyPairSyncMethod = (
+export type RSAGenerateKeyPairSyncMethod = (
   keyVariant: RSAKeyVariant,
   modulusLength: number,
   publicExponent: number,
+  ...rest: any[]
+) => [error: unknown, publicBuffer: any, privateBuffer: any];
+
+export type ECGenerateKeyPairMethod = (
+  namedCurve: NamedCurve,
+  paramEncodingFlag: ECCurve,
+  ...rest: any[]
+) => Promise<[error: unknown, publicBuffer: any, privateBuffer: any]>;
+
+export type ECGenerateKeyPairSyncMethod = (
+  namedCurve: NamedCurve,
+  paramEncodingFlag: ECCurve,
   ...rest: any[]
 ) => [error: unknown, publicBuffer: any, privateBuffer: any];

--- a/src/NativeQuickCrypto/Cipher.ts
+++ b/src/NativeQuickCrypto/Cipher.ts
@@ -1,8 +1,7 @@
 import type { BinaryLike } from '../Utils';
 import type { Buffer } from '@craftzdog/react-native-buffer';
 
-// TODO(osp) on node this is defined on the native side
-// Need to do the same so that values are always in sync
+// TODO: until shared, keep in sync with C++ side (cpp/Utils/MGLUtils.h)
 export enum KeyVariant {
   RSA_SSA_PKCS1_v1_5,
   RSA_PSS,

--- a/src/NativeQuickCrypto/Cipher.ts
+++ b/src/NativeQuickCrypto/Cipher.ts
@@ -1,14 +1,16 @@
 import type { BinaryLike } from '../Utils';
 import type { Buffer } from '@craftzdog/react-native-buffer';
-import type { NamedCurve } from '../keys';
-import type { ECCurve } from '../Cipher';
 
 // TODO(osp) on node this is defined on the native side
 // Need to do the same so that values are always in sync
-export enum RSAKeyVariant {
-  kKeyVariantRSA_SSA_PKCS1_v1_5,
-  kKeyVariantRSA_PSS,
-  kKeyVariantRSA_OAEP,
+export enum KeyVariant {
+  RSA_SSA_PKCS1_v1_5,
+  RSA_PSS,
+  RSA_OAEP,
+  DSA,
+  EC,
+  NID,
+  DH,
 }
 
 export type InternalCipher = {
@@ -57,28 +59,12 @@ export type PrivateDecryptMethod = (
   oaepLabel: any
 ) => Buffer;
 
-export type RSAGenerateKeyPairMethod = (
-  keyVariant: RSAKeyVariant,
-  modulusLength: number,
-  publicExponent: number,
+export type GenerateKeyPairMethod = (
+  keyVariant: KeyVariant,
   ...rest: any[]
 ) => Promise<[error: unknown, publicBuffer: any, privateBuffer: any]>;
 
-export type RSAGenerateKeyPairSyncMethod = (
-  keyVariant: RSAKeyVariant,
-  modulusLength: number,
-  publicExponent: number,
-  ...rest: any[]
-) => [error: unknown, publicBuffer: any, privateBuffer: any];
-
-export type ECGenerateKeyPairMethod = (
-  namedCurve: NamedCurve,
-  paramEncodingFlag: ECCurve,
-  ...rest: any[]
-) => Promise<[error: unknown, publicBuffer: any, privateBuffer: any]>;
-
-export type ECGenerateKeyPairSyncMethod = (
-  namedCurve: NamedCurve,
-  paramEncodingFlag: ECCurve,
+export type GenerateKeyPairSyncMethod = (
+  keyVariant: KeyVariant,
   ...rest: any[]
 ) => [error: unknown, publicBuffer: any, privateBuffer: any];

--- a/src/NativeQuickCrypto/NativeQuickCrypto.ts
+++ b/src/NativeQuickCrypto/NativeQuickCrypto.ts
@@ -8,10 +8,8 @@ import type {
   CreateDecipherMethod,
   PublicEncryptMethod,
   PrivateDecryptMethod,
-  RSAGenerateKeyPairMethod,
-  RSAGenerateKeyPairSyncMethod,
-  ECGenerateKeyPairMethod,
-  ECGenerateKeyPairSyncMethod,
+  GenerateKeyPairMethod,
+  GenerateKeyPairSyncMethod,
 } from './Cipher';
 import type { CreateSignMethod, CreateVerifyMethod } from './sig';
 import type { webcrypto } from './webcrypto';
@@ -26,10 +24,8 @@ interface NativeQuickCryptoSpec {
   publicEncrypt: PublicEncryptMethod;
   publicDecrypt: PublicEncryptMethod;
   privateDecrypt: PrivateDecryptMethod;
-  generateKeyPairRSA: RSAGenerateKeyPairMethod;
-  generateKeyPairSyncRSA: RSAGenerateKeyPairSyncMethod;
-  generateKeyPairEC: ECGenerateKeyPairMethod;
-  generateKeyPairSyncEC: ECGenerateKeyPairSyncMethod;
+  generateKeyPair: GenerateKeyPairMethod;
+  generateKeyPairSync: GenerateKeyPairSyncMethod;
   createSign: CreateSignMethod;
   createVerify: CreateVerifyMethod;
   webcrypto: webcrypto;

--- a/src/NativeQuickCrypto/NativeQuickCrypto.ts
+++ b/src/NativeQuickCrypto/NativeQuickCrypto.ts
@@ -8,8 +8,10 @@ import type {
   CreateDecipherMethod,
   PublicEncryptMethod,
   PrivateDecryptMethod,
-  GenerateKeyPairMethod,
-  GenerateKeyPairSyncMethod,
+  RSAGenerateKeyPairMethod,
+  RSAGenerateKeyPairSyncMethod,
+  ECGenerateKeyPairMethod,
+  ECGenerateKeyPairSyncMethod,
 } from './Cipher';
 import type { CreateSignMethod, CreateVerifyMethod } from './sig';
 import type { webcrypto } from './webcrypto';
@@ -24,8 +26,10 @@ interface NativeQuickCryptoSpec {
   publicEncrypt: PublicEncryptMethod;
   publicDecrypt: PublicEncryptMethod;
   privateDecrypt: PrivateDecryptMethod;
-  generateKeyPair: GenerateKeyPairMethod;
-  generateKeyPairSync: GenerateKeyPairSyncMethod;
+  generateKeyPairRSA: RSAGenerateKeyPairMethod;
+  generateKeyPairSyncRSA: RSAGenerateKeyPairSyncMethod;
+  generateKeyPairEC: ECGenerateKeyPairMethod;
+  generateKeyPairSyncEC: ECGenerateKeyPairSyncMethod;
   createSign: CreateSignMethod;
   createVerify: CreateVerifyMethod;
   webcrypto: webcrypto;

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -508,6 +508,8 @@ export const normalizeAlgorithm = (
 
   // 4.
   let algName = algorithm.name;
+  // @ts-expect-error
+  if (algName === undefined) return { name: undefined };
 
   // 5.
   let desiredType: string | null | undefined;

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -600,6 +600,16 @@ export const validateByteLength = (
   }
 };
 
+export const getUsagesUnion = (usageSet: KeyUsage[], ...usages: KeyUsage[]) => {
+  const newset: KeyUsage[] = [];
+  for (let n = 0; n < usages.length; n++) {
+    if (!usages[n] || usages[n] === undefined) continue;
+    if (usageSet.includes(usages[n] as KeyUsage))
+      newset.push(usages[n] as KeyUsage);
+  }
+  return newset;
+};
+
 const kKeyOps: {
   [key in KeyUsage]: number;
 } = {

--- a/src/ec.ts
+++ b/src/ec.ts
@@ -1,4 +1,3 @@
-import { KeyObject } from 'crypto';
 import { generateKeyPairPromise, type GenerateKeyPairOptions } from './Cipher';
 import { NativeQuickCrypto } from './NativeQuickCrypto/NativeQuickCrypto';
 import {
@@ -350,16 +349,12 @@ export const ecGenerateKey = async (
 
   const keyAlgorithm = { name, namedCurve };
 
-  const publicKey = new InternalCryptoKey(
-    keypair.publicKey as KeyObjectHandle,
-    keyAlgorithm,
-    publicUsages,
-    true
-  );
-  // const publicKey = new PublicKeyObject(pub as KeyObjectHandle);
+  const pub = new PublicKeyObject(keypair?.publicKey as KeyObjectHandle);
+  const publicKey = new CryptoKey(pub, keyAlgorithm, publicUsages, true);
 
-  const privateKey = new InternalCryptoKey(
-    keypair.privateKey as KeyObjectHandle,
+  const priv = new PrivateKeyObject(keypair?.privateKey as KeyObjectHandle);
+  const privateKey = new CryptoKey(
+    priv,
     keyAlgorithm,
     privateUsages,
     extractable
@@ -367,17 +362,3 @@ export const ecGenerateKey = async (
 
   return { publicKey, privateKey };
 };
-
-//   const publicKey =
-//     new InternalCryptoKey(
-//       keypair.publicKey,
-//       keyAlgorithm,
-//       publicUsages,
-//       true);
-
-//   const privateKey =
-//     new InternalCryptoKey(
-//       keypair.privateKey,
-//       keyAlgorithm,
-//       privateUsages,
-//       extractable);

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -28,16 +28,16 @@ export type AnyAlgorithm =
 
 export type HashAlgorithm = 'SHA-1' | 'SHA-256' | 'SHA-384' | 'SHA-512';
 
+export type KeyPairType = 'rsa' | 'rsa-pss' | 'ec';
+
+export type RSAKeyPairAlgorithm = 'RSASSA-PKCS1-v1_5' | 'RSA-PSS' | 'RSA-OAEP';
+export type ECKeyPairAlgorithm = 'ECDSA' | 'ECDH';
+export type CFRGKeyPairAlgorithm = 'Ed25519' | 'Ed448' | 'X25519' | 'X448';
+
 export type KeyPairAlgorithm =
-  | 'ECDSA'
-  | 'ECDH'
-  | 'Ed25519'
-  | 'Ed448'
-  | 'RSASSA-PKCS1-v1_5'
-  | 'RSA-PSS'
-  | 'RSA-OAEP'
-  | 'X25519'
-  | 'X448';
+  | RSAKeyPairAlgorithm
+  | ECKeyPairAlgorithm
+  | CFRGKeyPairAlgorithm;
 
 export type SecretKeyAlgorithm =
   | 'HMAC'

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -522,18 +522,6 @@ export class CryptoKey {
   }
 }
 
-// ObjectDefineProperties(CryptoKey.prototype, {
-//   type: kEnumerableProperty,
-//   extractable: kEnumerableProperty,
-//   algorithm: kEnumerableProperty,
-//   usages: kEnumerableProperty,
-//   [SymbolToStringTag]: {
-//     __proto__: null,
-//     configurable: true,
-//     value: 'CryptoKey',
-//   },
-// });
-
 class KeyObject {
   handle: KeyObjectHandle;
   type: 'public' | 'secret' | 'private' | 'unknown' = 'unknown';
@@ -573,14 +561,6 @@ class KeyObject {
   //   );
   // }
 }
-
-// ObjectDefineProperties(KeyObject.prototype, {
-//   [SymbolToStringTag]: {
-//     __proto__: null,
-//     configurable: true,
-//     value: 'KeyObject',
-//   },
-// });
 
 export class SecretKeyObject extends KeyObject {
   constructor(handle: KeyObjectHandle) {

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -175,6 +175,11 @@ const encodingNames = {
   [KeyEncoding.kKeyEncodingSEC1]: 'sec1',
 };
 
+export type CryptoKeyPair = {
+  publicKey: any;
+  privateKey: any;
+};
+
 function option(name: string, objName: string | undefined) {
   return objName === undefined
     ? `options.${name}`

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -662,3 +662,7 @@ export class PrivateKeyObject extends AsymmetricKeyObject {
     return this.handle.export(format, type, cipher, passphrase);
   }
 }
+
+export const isCryptoKey = (obj: any): boolean => {
+  return obj !== null && obj?.keyObject !== undefined;
+};

--- a/src/subtle.ts
+++ b/src/subtle.ts
@@ -431,7 +431,7 @@ class Subtle {
       //   break;
       default:
         throw lazyDOMException(
-          `Unrecognized algorithm name '$${algorithm}'`,
+          `Unrecognized algorithm name '${algorithm.name}'`,
           'NotSupportedError'
         );
     }

--- a/src/subtle.ts
+++ b/src/subtle.ts
@@ -430,9 +430,9 @@ class Subtle {
       //   result = await aesGenerateKey(algorithm, extractable, keyUsages);
       //   break;
       default:
-        throw lazyDOMException(
-          `Unrecognized algorithm name '${algorithm.name}'`,
-          'NotSupportedError'
+        throw new Error(
+          `'subtle.generateKey()' is not implemented for ${algorithm.name}.
+            Unrecognized algorithm name`
         );
     }
 


### PR DESCRIPTION
Add support for `subtle.generateKey()` for `EC` formats (ECDSA, ECDH)

closes #59 
closes #80 
closes #288
