### PR TITLE
feat: add support for Uint8Array

### DIFF
--- a/example/src/testing/Tests/webcryptoTests/import_export.ts
+++ b/example/src/testing/Tests/webcryptoTests/import_export.ts
@@ -92,7 +92,7 @@ describe('subtle - importKey / exportKey', () => {
         await subtle.importKey('raw', 1, { name: 'PBKDF2' }, false, [
           'deriveBits',
         ]),
-      'Invalid argument type for "key". Need ArrayBuffer, KeyObject, CryptoKey, string'
+      'Invalid argument type for "key". Need ArrayBuffer, TypedArray, KeyObject, CryptoKey, string'
     );
     await assertThrowsAsync(
       async () =>
@@ -170,6 +170,28 @@ describe('subtle - importKey / exportKey', () => {
         ),
       '"subtle.importKey()" is not implemented for HMAC'
       // TODO: will be 'Invalid keyData'
+    );
+  });
+
+  it('Good Input - Uint8Array', async () => {
+    await subtle.importKey(
+      'raw',
+      new Uint8Array([
+        117, 110, 102, 97, 105, 114, 32, 99, 117, 108, 116, 117, 114, 101, 32,
+        115, 117, 105, 116, 32, 112, 97, 116, 104, 32, 119, 111, 114, 108, 100,
+        32, 104, 105, 103, 104, 32, 116, 111, 109, 111, 114, 114, 111, 119, 32,
+        118, 105, 100, 101, 111, 32, 114, 101, 99, 105, 112, 101, 32, 99, 114,
+        105, 109, 101, 32, 101, 110, 103, 105, 110, 101, 32, 119, 105, 100, 116,
+        104, 32, 111, 102, 116, 101, 110, 32, 116, 97, 112, 101, 32, 116, 114,
+        101, 110, 100, 32, 99, 111, 112, 112, 101, 114, 32, 100, 111, 117, 98,
+        108, 101, 32, 103, 108, 111, 114, 121, 32, 100, 111, 99, 116, 111, 114,
+        32, 101, 110, 101, 114, 103, 121, 32, 103, 111, 111, 115, 101, 32, 115,
+        101, 99, 111, 110, 100, 32, 97, 98, 115, 116, 114, 97, 99, 116, 32, 107,
+        110, 111, 99, 107,
+      ]),
+      { name: 'PBKDF2' },
+      false,
+      ['deriveBits']
     );
   });
 

--- a/example/src/testing/Tests/webcryptoTests/import_export.ts
+++ b/example/src/testing/Tests/webcryptoTests/import_export.ts
@@ -7,10 +7,13 @@ import {
 } from 'react-native-quick-base64';
 import crypto from 'react-native-quick-crypto';
 import { describe, it } from '../../MochaRNAdapter';
-import { ab2str, binaryLikeToArrayBuffer } from '../../../../../src/Utils';
+import {
+  ab2str,
+  binaryLikeToArrayBuffer,
+  type TypedArray,
+} from '../../../../../src/Utils';
 import { assertThrowsAsync } from '../util';
 import type { JWK, KeyUsage, NamedCurve } from '../../../../../src/keys';
-import type { RandomTypedArrays } from '../../../../../src/random';
 
 const { subtle } = crypto;
 
@@ -235,7 +238,7 @@ describe('subtle - importKey / exportKey', () => {
       expect(key.keyAlgorithm.length).to.equal(256);
     });
 
-    const test = (rawKeyData: RandomTypedArrays, descr: string): void => {
+    const test = (rawKeyData: TypedArray, descr: string): void => {
       it(`AES import raw / export jwk (${descr})`, async () => {
         const keyData = binaryLikeToArrayBuffer(rawKeyData);
         const keyB64 = arrayBufferToBase64(keyData, true);

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -13,7 +13,7 @@ import type {
 import { type CipherKey } from 'crypto'; // @types/node
 
 export type BufferLike = ArrayBuffer | Buffer | ArrayBufferView;
-export type BinaryLike = string | ArrayBuffer | Buffer;
+export type BinaryLike = string | ArrayBuffer | Buffer | TypedArray;
 export type BinaryLikeNode = CipherKey | BinaryLike;
 
 export type BinaryToTextEncoding = 'base64' | 'base64url' | 'hex' | 'binary';
@@ -26,6 +26,17 @@ export type Encoding =
 
 // TODO(osp) should buffer be part of the Encoding type?
 export type CipherEncoding = Encoding | 'buffer';
+
+export type TypedArray =
+  | Uint8Array
+  | Uint8ClampedArray
+  | Uint16Array
+  | Uint32Array
+  | Int8Array
+  | Int16Array
+  | Int32Array
+  | Float32Array
+  | Float64Array;
 
 type DOMName =
   | string

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -440,10 +440,11 @@ function prepareSecretKey(
     }
   }
 
-  /**
-   * We should exclude both `CryptoKey` and `KeyObject` because they are not supported by `binaryLikeToArrayBuffer`.
-   */
-  if (!(key instanceof CryptoKey) && !(key instanceof KeyObject)) {
+  if (key instanceof ArrayBuffer) {
+    return key;
+  }
+
+  if (typeof key === 'string' || key instanceof Uint8Array) {
     return binaryLikeToArrayBuffer(key, encoding);
   }
 

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -417,7 +417,7 @@ export function parsePrivateKeyEncoding(
 }
 
 function prepareSecretKey(
-  key: ArrayBuffer | KeyObject | CryptoKey | string,
+  key: ArrayBuffer | KeyObject | CryptoKey | Uint8Array | string,
   encoding?: string,
   bufferOnly = false
 ): any {

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -5,6 +5,7 @@ import {
 } from './Utils';
 import type { KeyObjectHandle } from './NativeQuickCrypto/webcrypto';
 import { NativeQuickCrypto } from './NativeQuickCrypto/NativeQuickCrypto';
+import type { RandomTypedArrays } from './random';
 
 export const kNamedCurveAliases = {
   'P-256': 'prime256v1',
@@ -417,7 +418,7 @@ export function parsePrivateKeyEncoding(
 }
 
 function prepareSecretKey(
-  key: ArrayBuffer | KeyObject | CryptoKey | Uint8Array | string,
+  key: ArrayBuffer | KeyObject | CryptoKey | RandomTypedArrays | string,
   encoding?: string,
   bufferOnly = false
 ): any {

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -448,6 +448,10 @@ function prepareSecretKey(
     return binaryLikeToArrayBuffer(key, encoding);
   }
 
+  if (key instanceof Uint8Array) {
+    return key.buffer;
+  }
+
   throw new Error(
     'Invalid argument type for "key". Need ArrayBuffer, KeyObject, CryptoKey, string'
   );

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -440,20 +440,15 @@ function prepareSecretKey(
     }
   }
 
-  if (key instanceof ArrayBuffer) {
-    return key;
-  }
-
-  if (typeof key === 'string') {
+  /**
+   * We should exclude both `CryptoKey` and `KeyObject` because they are not supported by `binaryLikeToArrayBuffer`.
+   */
+  if (!(key instanceof CryptoKey) && !(key instanceof KeyObject)) {
     return binaryLikeToArrayBuffer(key, encoding);
   }
 
-  if (key instanceof Uint8Array) {
-    return key.buffer;
-  }
-
   throw new Error(
-    'Invalid argument type for "key". Need ArrayBuffer, KeyObject, CryptoKey, string'
+    'Invalid argument type for "key". Need ArrayBuffer, TypedArray, KeyObject, CryptoKey, string'
   );
 }
 

--- a/src/random.ts
+++ b/src/random.ts
@@ -1,18 +1,9 @@
 import { NativeQuickCrypto } from './NativeQuickCrypto/NativeQuickCrypto';
 import { Buffer } from '@craftzdog/react-native-buffer';
+import type { TypedArray } from './Utils';
 
 const random = NativeQuickCrypto.random;
 
-type TypedArray =
-  | Uint8Array
-  | Uint8ClampedArray
-  | Uint16Array
-  | Uint32Array
-  | Int8Array
-  | Int16Array
-  | Int32Array
-  | Float32Array
-  | Float64Array;
 type ArrayBufferView = TypedArray | DataView | ArrayBufferLike | Buffer;
 
 export function randomFill<T extends ArrayBufferView>(
@@ -266,19 +257,7 @@ function asyncRefillRandomIntCache() {
   });
 }
 
-// Really just the Web Crypto API alternative
-// to require('crypto').randomFillSync() with an
-// additional limitation that the input buffer is
-// not allowed to exceed 65536 bytes, and can only
-// be an integer-type TypedArray.
-export type RandomTypedArrays =
-  | Int8Array
-  | Int16Array
-  | Int32Array
-  | Uint8Array
-  | Uint16Array
-  | Uint32Array;
-export function getRandomValues(data: RandomTypedArrays) {
+export function getRandomValues(data: TypedArray) {
   if (data.byteLength > 65536) {
     throw new Error('The requested length exceeds 65,536 bytes');
   }


### PR DESCRIPTION
This PR adds support for keys such as uint8array for the `prepareSecretKey` method, I noticed while trying to generate a mnemonic with the following code:

```ts
import { generateMnemonic as generateBIP39Mnemonic } from '@scure/bip39';
import { wordlist } from '@scure/bip39/wordlists/english';
```

That due to the checks within `prepareSecretKey`, keys in the format of Uint8Array were not supported and this generated the following exception:
```
Invalid argument type for "key". Need ArrayBuffer, KeyObject, CryptoKey, string
```