### PR TITLE
feat: `subtle.encrypt()` & `subtle.decrypt()` support for `aes`

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -45,6 +45,7 @@ add_library(
   "../cpp/webcrypto/MGLWebCrypto.cpp"
   "../cpp/webcrypto/crypto_aes.cpp"
   "../cpp/webcrypto/crypto_ec.cpp"
+  "../cpp/webcrypto/crypto_keygen.cpp"
 )
 
 target_include_directories(

--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -43,6 +43,7 @@ add_library(
   "../cpp/Sig/MGLVerifyInstaller.cpp"
   "../cpp/Sig/MGLSignHostObjects.cpp"
   "../cpp/webcrypto/MGLWebCrypto.cpp"
+  "../cpp/webcrypto/crypto_aes.cpp"
   "../cpp/webcrypto/crypto_ec.cpp"
 )
 

--- a/cpp/JSIUtils/MGLJSIUtils.h
+++ b/cpp/JSIUtils/MGLJSIUtils.h
@@ -30,4 +30,12 @@ inline bool CheckIsInt32(const jsi::Value &value) {
   return (d >= std::numeric_limits<int32_t>::lowest() && d <= std::numeric_limits<int32_t>::max());
 }
 
+inline bool CheckIsUint32(const jsi::Value &value) {
+  if (!value.isNumber()) {
+    return false;
+  }
+  double d = value.asNumber();
+  return (d >= std::numeric_limits<uint32_t>::lowest() && d <= std::numeric_limits<uint32_t>::max());
+}
+
 #endif /* MGLJSIUtils_h */

--- a/cpp/MGLKeys.cpp
+++ b/cpp/MGLKeys.cpp
@@ -562,7 +562,7 @@ jsi::Value ManagedEVPPKey::ToEncodedPublicKey(jsi::Runtime& rt,
     // Note that this has the downside of containing sensitive data of the
     // private key.
     auto data = KeyObjectData::CreateAsymmetric(kKeyTypePublic, std::move(key));
-    auto handle = KeyObjectHandle::Create(rt, data);
+    auto handle = KeyObjectHandle::Create(data);
     auto out = jsi::Object::createFromHostObject(rt, handle);
     return jsi::Value(std::move(out));
   } else
@@ -583,7 +583,7 @@ jsi::Value ManagedEVPPKey::ToEncodedPrivateKey(jsi::Runtime& rt,
   if (!key) return {};
   if (config.output_key_object_) {
     auto data = KeyObjectData::CreateAsymmetric(kKeyTypePrivate, std::move(key));
-    auto handle = KeyObjectHandle::Create(rt, data);
+    auto handle = KeyObjectHandle::Create(data);
     auto out = jsi::Object::createFromHostObject(rt, handle);
     return jsi::Value(std::move(out));
   } else
@@ -907,8 +907,7 @@ jsi::Value KeyObjectHandle::get(
 //   registry->Register(Equals);
 // }
 
-std::shared_ptr<KeyObjectHandle> KeyObjectHandle::Create(jsi::Runtime &rt,
-                                                         std::shared_ptr<KeyObjectData> data) {
+std::shared_ptr<KeyObjectHandle> KeyObjectHandle::Create(std::shared_ptr<KeyObjectData> data) {
   auto handle = std::make_shared<KeyObjectHandle>();
   handle->data_ = data;
   return handle;

--- a/cpp/MGLKeys.h
+++ b/cpp/MGLKeys.h
@@ -168,8 +168,7 @@ class JSI_EXPORT KeyObjectHandle: public jsi::HostObject {
     jsi::Value get(jsi::Runtime &rt, const jsi::PropNameID &propNameID);
     const std::shared_ptr<KeyObjectData>& Data();
 
-    static std::shared_ptr<KeyObjectHandle> Create(jsi::Runtime &rt,
-                                                   std::shared_ptr<KeyObjectData> data);
+    static std::shared_ptr<KeyObjectHandle> Create(std::shared_ptr<KeyObjectData> data);
 
  protected:
     jsi::Value Export(jsi::Runtime &rt);

--- a/cpp/MGLQuickCryptoHostObject.cpp
+++ b/cpp/MGLQuickCryptoHostObject.cpp
@@ -113,12 +113,12 @@ MGLQuickCryptoHostObject::MGLQuickCryptoHostObject(
   // createVerify
   this->fields.push_back(getVerifyFieldDefinition(jsCallInvoker, workerQueue));
 
-  // subtle API created from a simple jsi::Object
-  // because this FieldDefinition is only good for returning
-  // objects and too convoluted
-    this->fields.push_back(JSI_VALUE("webcrypto", {
-      return createWebCryptoObject(runtime);
-    }));
+  // subtle API
+  this->fields.push_back(JSI_VALUE("webcrypto", {
+    auto hostObject = std::make_shared<MGLWebCryptoHostObject>(
+        jsCallInvoker, workerQueue);
+    return jsi::Object::createFromHostObject(runtime, hostObject);
+  }));
 }
 
 }  // namespace margelo

--- a/cpp/Utils/MGLUtils.cpp
+++ b/cpp/Utils/MGLUtils.cpp
@@ -222,4 +222,38 @@ std::string DecodeBase64(const std::string &in, bool remove_linebreaks) {
   return base64_decode(in, remove_linebreaks);
 }
 
+MUST_USE_RESULT CSPRNGResult CSPRNG(void* buffer, size_t length) {
+  unsigned char* buf = static_cast<unsigned char*>(buffer);
+  do {
+    if (1 == RAND_status()) {
+#if OPENSSL_VERSION_MAJOR >= 3
+      if (1 == RAND_bytes_ex(nullptr, buf, length, 0)) return {true};
+#else
+      while (length > INT_MAX && 1 == RAND_bytes(buf, INT_MAX)) {
+        buf += INT_MAX;
+        length -= INT_MAX;
+      }
+      if (length <= INT_MAX && 1 == RAND_bytes(buf, static_cast<int>(length)))
+        return {true};
+#endif
+    }
+#if OPENSSL_VERSION_MAJOR >= 3
+    const auto code = ERR_peek_last_error();
+    // A misconfigured OpenSSL 3 installation may report 1 from RAND_poll()
+    // and RAND_status() but fail in RAND_bytes() if it cannot look up
+    // a matching algorithm for the CSPRNG.
+    if (ERR_GET_LIB(code) == ERR_LIB_RAND) {
+      const auto reason = ERR_GET_REASON(code);
+      if (reason == RAND_R_ERROR_INSTANTIATING_DRBG ||
+          reason == RAND_R_UNABLE_TO_FETCH_DRBG ||
+          reason == RAND_R_UNABLE_TO_CREATE_DRBG) {
+        return {false};
+      }
+    }
+#endif
+  } while (1 == RAND_poll());
+
+  return {false};
+}
+
 }  // namespace margelo

--- a/cpp/Utils/MGLUtils.h
+++ b/cpp/Utils/MGLUtils.h
@@ -50,6 +50,7 @@ using EVPMDPointer = DeleteFnPtr<EVP_MD_CTX, EVP_MD_CTX_free>;
 using ECDSASigPointer = DeleteFnPtr<ECDSA_SIG, ECDSA_SIG_free>;
 using ECKeyPointer = DeleteFnPtr<EC_KEY, EC_KEY_free>;
 using ECPointPointer = DeleteFnPtr<EC_POINT, EC_POINT_free>;
+using CipherCtxPointer = DeleteFnPtr<EVP_CIPHER_CTX, EVP_CIPHER_CTX_free>;
 
 template <typename T>
 class NonCopyableMaybe {

--- a/cpp/Utils/MGLUtils.h
+++ b/cpp/Utils/MGLUtils.h
@@ -52,6 +52,26 @@ using ECKeyPointer = DeleteFnPtr<EC_KEY, EC_KEY_free>;
 using ECPointPointer = DeleteFnPtr<EC_POINT, EC_POINT_free>;
 using CipherCtxPointer = DeleteFnPtr<EVP_CIPHER_CTX, EVP_CIPHER_CTX_free>;
 
+
+#ifdef __GNUC__
+#define MUST_USE_RESULT __attribute__((warn_unused_result))
+#else
+#define MUST_USE_RESULT
+#endif
+
+struct CSPRNGResult {
+  const bool ok;
+  MUST_USE_RESULT bool is_ok() const { return ok; }
+  MUST_USE_RESULT bool is_err() const { return !ok; }
+};
+
+// Either succeeds with exactly |length| bytes of cryptographically
+// strong pseudo-random data, or fails. This function may block.
+// Don't assume anything about the contents of |buffer| on error.
+// As a special case, |length == 0| can be used to check if the CSPRNG
+// is properly seeded without consuming entropy.
+MUST_USE_RESULT CSPRNGResult CSPRNG(void* buffer, size_t length);
+
 template <typename T>
 class NonCopyableMaybe {
  public:
@@ -298,6 +318,11 @@ enum KeyVariant {
   kvEC,
   kvNID,
   kvDH,
+};
+
+enum FnMode {
+  kAsync,
+  kSync,
 };
 
 }  // namespace margelo

--- a/cpp/webcrypto/MGLWebCrypto.cpp
+++ b/cpp/webcrypto/MGLWebCrypto.cpp
@@ -70,11 +70,11 @@ jsi::Value createWebCryptoObject(jsi::Runtime &rt) {
         return toJSI(rt, std::move(out));
     });
 
-    auto generateSecretKey = HOSTFN("generateSecretKey", 2) {
+    auto generateSecretKey = HOSTFN("generateSecretKey", 1) {
         return SecretKeyGen::DoKeyGen(rt, args);
     });
 
-    auto generateSecretKeySync = HOSTFN("generateSecretKeySync", 2) {
+    auto generateSecretKeySync = HOSTFN("generateSecretKeySync", 1) {
         return SecretKeyGen::DoKeyGenSync(rt, args);
     });
 
@@ -86,11 +86,12 @@ jsi::Value createWebCryptoObject(jsi::Runtime &rt) {
         return ssv.EncodeOutput(rt, params, out);
     });
 
+    obj.setProperty(rt, "aesCipher", std::move(aesCipher));
     obj.setProperty(rt,
                     "createKeyObjectHandle",
                     std::move(createKeyObjectHandle));
     obj.setProperty(rt, "ecExportKey", std::move(ecExportKey));
-    obj.setProperty(rt, "generateSecretKey", std::move(generateSecretKey));
+    obj.setProperty(rt, "generateSecretKey", std::move(generateSecretKeySync));
     obj.setProperty(rt, "generateSecretKeySync", std::move(generateSecretKeySync));
     obj.setProperty(rt, "signVerify", std::move(signVerify));
     return obj;

--- a/cpp/webcrypto/MGLWebCrypto.cpp
+++ b/cpp/webcrypto/MGLWebCrypto.cpp
@@ -32,69 +32,67 @@ namespace margelo {
 namespace jsi = facebook::jsi;
 namespace react = facebook::react;
 
-jsi::Value createWebCryptoObject(jsi::Runtime &rt) {
-    auto obj = jsi::Object(rt);
+MGLWebCryptoHostObject::MGLWebCryptoHostObject(
+  std::shared_ptr<react::CallInvoker> jsCallInvoker,
+  std::shared_ptr<DispatchQueue::dispatch_queue> workerQueue)
+  : MGLSmartHostObject(jsCallInvoker, workerQueue) {
 
-    auto aesCipher = HOSTFN("aesCipher", 4) {
-        auto aes = AESCipher();
-        auto params = aes.GetParamsFromJS(rt, args);
-        ByteSource out;
-        WebCryptoCipherStatus status = aes.DoCipher(params, &out);
-        if (status != WebCryptoCipherStatus::OK) {
-            throw jsi::JSError(rt, "error in DoCipher, status: " +
-                std::to_string(static_cast<int>(status)));
-        }
-        return toJSI(rt, std::move(out));
-    });
+  auto aesCipher = JSIF([=]) {
+    auto aes = AESCipher();
+    auto params = aes.GetParamsFromJS(runtime, arguments);
+    ByteSource out;
+    WebCryptoCipherStatus status = aes.DoCipher(params, &out);
+    if (status != WebCryptoCipherStatus::OK) {
+      throw jsi::JSError(runtime, "error in DoCipher, status: " +
+        std::to_string(static_cast<int>(status)));
+    }
+    return toJSI(runtime, std::move(out));
+  };
 
-    auto createKeyObjectHandle = HOSTFN("createKeyObjectHandle", 0) {
-        auto keyObjectHandleHostObject =
-            std::make_shared<KeyObjectHandle>();
-        return jsi::Object::createFromHostObject(rt, keyObjectHandleHostObject);
-    });
+  auto createKeyObjectHandle = JSIF([=]) {
+    auto keyObjectHandleHostObject = std::make_shared<KeyObjectHandle>();
+    return jsi::Object::createFromHostObject(runtime, keyObjectHandleHostObject);
+  };
 
-    auto ecExportKey = HOSTFN("ecExportKey", 2) {
-        ByteSource out;
-        std::shared_ptr<KeyObjectHandle> handle =
-            std::static_pointer_cast<KeyObjectHandle>(
-                args[1].asObject(rt).getHostObject(rt));
-        std::shared_ptr<KeyObjectData> key_data = handle->Data();
-        WebCryptoKeyExportStatus status = ECDH::doExport(rt,
-                                                         key_data,
-                                                         static_cast<WebCryptoKeyFormat>(args[0].asNumber()),
-                                                         {}, // blank params
-                                                         &out);
-        if (status != WebCryptoKeyExportStatus::OK) {
-            throw jsi::JSError(rt, "error exporting key, status: " + std::to_string(static_cast<int>(status)));
-        }
-        return toJSI(rt, std::move(out));
-    });
+  auto ecExportKey = JSIF([=]) {
+    ByteSource out;
+    std::shared_ptr<KeyObjectHandle> handle =
+      std::static_pointer_cast<KeyObjectHandle>(
+        arguments[1].asObject(runtime).getHostObject(runtime));
+    std::shared_ptr<KeyObjectData> key_data = handle->Data();
+    WebCryptoKeyExportStatus status = ECDH::doExport(runtime,
+                                                     key_data,
+                                                     static_cast<WebCryptoKeyFormat>(arguments[0].asNumber()),
+                                                     {}, // blank params
+                                                     &out);
+    if (status != WebCryptoKeyExportStatus::OK) {
+      throw jsi::JSError(runtime, "error exporting key, status: " + std::to_string(static_cast<int>(status)));
+    }
+    return toJSI(runtime, std::move(out));
+  };
 
-    auto generateSecretKey = HOSTFN("generateSecretKey", 1) {
-        return SecretKeyGen::DoKeyGen(rt, args);
-    });
+  auto generateSecretKeySync = JSIF([=]) {
+    auto skg = new SecretKeyGen();
+    CHECK(skg->GetParamsFromJS(runtime, arguments));
+    CHECK(skg->DoKeyGen());
+    auto out = jsi::Object::createFromHostObject(runtime, skg->GetHandle());
+    return jsi::Value(std::move(out));
+  };
 
-    auto generateSecretKeySync = HOSTFN("generateSecretKeySync", 1) {
-        return SecretKeyGen::DoKeyGenSync(rt, args);
-    });
+  auto signVerify = JSIF([=]) {
+    auto ssv = SubtleSignVerify();
+    auto params = ssv.GetParamsFromJS(runtime, arguments);
+    ByteSource out;
+    ssv.DoSignVerify(runtime, params, out);
+    return ssv.EncodeOutput(runtime, params, out);
+  };
 
-    auto signVerify = HOSTFN("signVerify", 4) {
-        auto ssv = SubtleSignVerify();
-        auto params = ssv.GetParamsFromJS(rt, args);
-        ByteSource out;
-        ssv.DoSignVerify(rt, params, out);
-        return ssv.EncodeOutput(rt, params, out);
-    });
-
-    obj.setProperty(rt, "aesCipher", std::move(aesCipher));
-    obj.setProperty(rt,
-                    "createKeyObjectHandle",
-                    std::move(createKeyObjectHandle));
-    obj.setProperty(rt, "ecExportKey", std::move(ecExportKey));
-    obj.setProperty(rt, "generateSecretKey", std::move(generateSecretKeySync));
-    obj.setProperty(rt, "generateSecretKeySync", std::move(generateSecretKeySync));
-    obj.setProperty(rt, "signVerify", std::move(signVerify));
-    return obj;
+  this->fields.push_back(buildPair("aesCipher", aesCipher));
+  this->fields.push_back(buildPair("createKeyObjectHandle", createKeyObjectHandle));
+  this->fields.push_back(buildPair("ecExportKey", ecExportKey));
+  this->fields.push_back(GenerateSecretKeyFieldDefinition(jsCallInvoker, workerQueue));
+  this->fields.push_back(buildPair("generateSecretKeySync", generateSecretKeySync));
+  this->fields.push_back(buildPair("signVerify", signVerify));
 };
 
 }  // namespace margelo

--- a/cpp/webcrypto/MGLWebCrypto.h
+++ b/cpp/webcrypto/MGLWebCrypto.h
@@ -27,7 +27,12 @@ enum WebCryptoKeyFormat {
   kWebCryptoKeyFormatJWK
 };
 
-jsi::Value createWebCryptoObject(jsi::Runtime &rt);
+class MGLWebCryptoHostObject : public MGLSmartHostObject {
+ public:
+  MGLWebCryptoHostObject(
+      std::shared_ptr<react::CallInvoker> jsCallInvoker,
+      std::shared_ptr<DispatchQueue::dispatch_queue> workerQueue);
+};
 
 }  // namespace margelo
 

--- a/cpp/webcrypto/crypto_aes.cpp
+++ b/cpp/webcrypto/crypto_aes.cpp
@@ -1,7 +1,7 @@
 #include "crypto_aes.h"
 
 #ifdef ANDROID
-#include "JSIUtils/MGLJSIMacros.h"
+#include "JSIUtils/MGLJSIUtils.h"
 #include "Utils/MGLUtils.h"
 #else
 #include "MGLJSIUtils.h"
@@ -318,7 +318,7 @@ ByteSource GetByteSourceFromJS(jsi::Runtime &rt,
   if (data.size() > INT_MAX) {
     throw jsi::JSError(rt, "arg is too big (> int32): " + name);
   }
-  return std::move(data);
+  return data;
 }
 
 bool ValidateIV(
@@ -509,7 +509,7 @@ AESCipherConfig AESCipher::GetParamsFromJS(jsi::Runtime &rt,
 }
 
 WebCryptoCipherStatus AESCipher::DoCipher(const AESCipherConfig &params,
-                                          ByteSource* out) {
+                                          ByteSource *out) {
   // TODO: threading / async here, as we don't have jsi::Runtime
 #define V(name, fn)                                                           \
   case kKeyVariantAES_ ## name:                                               \

--- a/cpp/webcrypto/crypto_aes.cpp
+++ b/cpp/webcrypto/crypto_aes.cpp
@@ -386,8 +386,6 @@ void UseDefaultIV(AESCipherConfig* params) {
 
 }  // namespace
 
-AESCipher::AESCipher() {}
-
 AESCipherConfig AESCipher::GetParamsFromJS(jsi::Runtime &rt,
                                           const jsi::Value *args) {
   AESCipherConfig params;
@@ -512,6 +510,7 @@ AESCipherConfig AESCipher::GetParamsFromJS(jsi::Runtime &rt,
 
 WebCryptoCipherStatus AESCipher::DoCipher(const AESCipherConfig &params,
                                           ByteSource* out) {
+  // TODO: threading / async here, as we don't have jsi::Runtime
 #define V(name, fn)                                                           \
   case kKeyVariantAES_ ## name:                                               \
     return fn(params, out);

--- a/cpp/webcrypto/crypto_aes.cpp
+++ b/cpp/webcrypto/crypto_aes.cpp
@@ -398,10 +398,14 @@ AESCipherConfig AESCipher::GetParamsFromJS(jsi::Runtime &rt,
   offset++;
 
   // key (handle)
+  if (!args[offset].isObject()) {
+    throw std::runtime_error("arg is not a KeyObjectHandle: key");
+  }
   std::shared_ptr<KeyObjectHandle> handle =
     std::static_pointer_cast<KeyObjectHandle>(
       args[offset].asObject(rt).getHostObject(rt));
   params.key = handle->Data();
+  offset++;
 
   // data
   params.data = GetByteSourceFromJS(rt, args[offset], "data");

--- a/cpp/webcrypto/crypto_aes.cpp
+++ b/cpp/webcrypto/crypto_aes.cpp
@@ -1,0 +1,525 @@
+#include "crypto_aes.h"
+
+#ifdef ANDROID
+#include "JSIUtils/MGLJSIMacros.h"
+#include "Utils/MGLUtils.h"
+#else
+#include "MGLJSIUtils.h"
+#include "MGLUtils.h"
+#endif
+
+namespace margelo {
+
+namespace {
+// Implements general AES encryption and decryption for CBC
+// The key_data must be a secret key.
+// On success, this function sets out to a new ByteSource
+// instance containing the results and returns WebCryptoCipherStatus::OK.
+WebCryptoCipherStatus AES_Cipher(const AESCipherConfig& params, ByteSource* out) {
+  CHECK_NOT_NULL(params.key);
+  CHECK_EQ(params.key->GetKeyType(), kKeyTypeSecret);
+
+  const int mode = EVP_CIPHER_mode(params.cipher);
+
+  CipherCtxPointer ctx(EVP_CIPHER_CTX_new());
+  EVP_CIPHER_CTX_init(ctx.get());
+  if (mode == EVP_CIPH_WRAP_MODE)
+    EVP_CIPHER_CTX_set_flags(ctx.get(), EVP_CIPHER_CTX_FLAG_WRAP_ALLOW);
+
+  const bool encrypt = params.mode == AESCipherConfig::Mode::kEncrypt;
+
+  if (!EVP_CipherInit_ex(
+          ctx.get(),
+          params.cipher,
+          nullptr,
+          nullptr,
+          nullptr,
+          encrypt)) {
+    // Cipher init failed
+    return WebCryptoCipherStatus::FAILED;
+  }
+
+  if (mode == EVP_CIPH_GCM_MODE && !EVP_CIPHER_CTX_ctrl(
+        ctx.get(),
+        EVP_CTRL_AEAD_SET_IVLEN,
+        params.iv.size(),
+        nullptr)) {
+    return WebCryptoCipherStatus::FAILED;
+  }
+
+  if (!EVP_CIPHER_CTX_set_key_length(
+          ctx.get(),
+          params.key->GetSymmetricKeySize()) ||
+      !EVP_CipherInit_ex(
+          ctx.get(),
+          nullptr,
+          nullptr,
+          reinterpret_cast<const unsigned char*>(params.key->GetSymmetricKey().c_str()),
+          params.iv.data<unsigned char>(),
+          encrypt)) {
+    return WebCryptoCipherStatus::FAILED;
+  }
+
+  size_t tag_len = 0;
+
+  if (mode == EVP_CIPH_GCM_MODE) {
+    switch (params.mode) {
+      case AESCipherConfig::Mode::kDecrypt:
+        // If in decrypt mode, the auth tag must be set in the params.tag.
+        CHECK(params.tag);
+        if (!EVP_CIPHER_CTX_ctrl(ctx.get(),
+                                 EVP_CTRL_AEAD_SET_TAG,
+                                 params.tag.size(),
+                                 const_cast<char*>(params.tag.data<char>()))) {
+          return WebCryptoCipherStatus::FAILED;
+        }
+        break;
+      case AESCipherConfig::Mode::kEncrypt:
+        // In decrypt mode, we grab the tag length here. We'll use it to
+        // ensure that that allocated buffer has enough room for both the
+        // final block and the auth tag. Unlike our other AES-GCM implementation
+        // in CipherBase, in WebCrypto, the auth tag is concatenated to the end
+        // of the generated ciphertext and returned in the same ArrayBuffer.
+        tag_len = params.length;
+        break;
+      default:
+        throw std::runtime_error("Unreachable code in AES_Cipher");
+    }
+  }
+
+  size_t total = 0;
+  int buf_len = params.data.size() + EVP_CIPHER_CTX_block_size(ctx.get()) + tag_len;
+  int out_len;
+
+  if (mode == EVP_CIPH_GCM_MODE &&
+      params.additional_data.size() &&
+      !EVP_CipherUpdate(
+            ctx.get(),
+            nullptr,
+            &out_len,
+            params.additional_data.data<unsigned char>(),
+            params.additional_data.size())) {
+    return WebCryptoCipherStatus::FAILED;
+  }
+
+  ByteSource::Builder buf(buf_len);
+
+  // In some outdated version of OpenSSL (e.g.
+  // ubi81_sharedlibs_openssl111fips_x64) may be used in sharedlib mode, the
+  // logic will be failed when input size is zero. The newly OpenSSL has fixed
+  // it up. But we still have to regard zero as special in Node.js code to
+  // prevent old OpenSSL failure.
+  //
+  // Refs: https://github.com/openssl/openssl/commit/420cb707b880e4fb649094241371701013eeb15f
+  // Refs: https://github.com/nodejs/node/pull/38913#issuecomment-866505244
+  if (params.data.size() == 0) {
+    out_len = 0;
+  } else if (!EVP_CipherUpdate(ctx.get(),
+                               buf.data<unsigned char>(),
+                               &out_len,
+                               params.data.data<unsigned char>(),
+                               params.data.size())) {
+    return WebCryptoCipherStatus::FAILED;
+  }
+
+  total += out_len;
+  CHECK_LE(out_len, buf_len);
+  out_len = EVP_CIPHER_CTX_block_size(ctx.get());
+  if (!EVP_CipherFinal_ex(
+          ctx.get(), buf.data<unsigned char>() + total, &out_len)) {
+    return WebCryptoCipherStatus::FAILED;
+  }
+  total += out_len;
+
+  // If using AES_GCM, grab the generated auth tag and append
+  // it to the end of the ciphertext.
+  if (params.mode == AESCipherConfig::Mode::kEncrypt && mode == EVP_CIPH_GCM_MODE) {
+    if (!EVP_CIPHER_CTX_ctrl(ctx.get(),
+                             EVP_CTRL_AEAD_GET_TAG,
+                             tag_len,
+                             buf.data<unsigned char>() + total))
+      return WebCryptoCipherStatus::FAILED;
+    total += tag_len;
+  }
+
+  // It's possible that we haven't used the full allocated space. Size down.
+  *out = std::move(buf).release(total);
+
+  return WebCryptoCipherStatus::OK;
+}
+
+// The AES_CTR implementation here takes it's inspiration from the chromium
+// implementation here:
+// https://github.com/chromium/chromium/blob/7af6cfd/components/webcrypto/algorithms/aes_ctr.cc
+
+template <typename T>
+T CeilDiv(T a, T b) {
+  return a == 0 ? 0 : 1 + (a - 1) / b;
+}
+
+BignumPointer GetCounter(const AESCipherConfig& params) {
+  unsigned int remainder = (params.length % CHAR_BIT);
+  const unsigned char* data = params.iv.data<unsigned char>();
+
+  if (remainder == 0) {
+    unsigned int byte_length = params.length / CHAR_BIT;
+    return BignumPointer(BN_bin2bn(
+        data + params.iv.size() - byte_length,
+        byte_length,
+        nullptr));
+  }
+
+  unsigned int byte_length =
+      CeilDiv(params.length, static_cast<size_t>(CHAR_BIT));
+
+  std::vector<unsigned char> counter(
+      data + params.iv.size() - byte_length,
+      data + params.iv.size());
+  counter[0] &= ~(0xFF << remainder);
+
+  return BignumPointer(BN_bin2bn(counter.data(), counter.size(), nullptr));
+}
+
+std::vector<unsigned char> BlockWithZeroedCounter(
+    const AESCipherConfig& params) {
+  unsigned int length_bytes = params.length / CHAR_BIT;
+  unsigned int remainder = params.length % CHAR_BIT;
+
+  const unsigned char* data = params.iv.data<unsigned char>();
+
+  std::vector<unsigned char> new_counter_block(data, data + params.iv.size());
+
+  size_t index = new_counter_block.size() - length_bytes;
+  memset(&new_counter_block.front() + index, 0, length_bytes);
+
+  if (remainder)
+    new_counter_block[index - 1] &= 0xFF << remainder;
+
+  return new_counter_block;
+}
+
+WebCryptoCipherStatus AES_CTR_Cipher2(
+    const AESCipherConfig& params,
+    const ByteSource &in,
+    unsigned const char* counter,
+    unsigned char* out) {
+  CipherCtxPointer ctx(EVP_CIPHER_CTX_new());
+  const bool encrypt = params.mode == AESCipherConfig::Mode::kEncrypt;
+
+  if (!EVP_CipherInit_ex(
+          ctx.get(),
+          params.cipher,
+          nullptr,
+          reinterpret_cast<const unsigned char*>(params.key->GetSymmetricKey().c_str()),
+          counter,
+          encrypt)) {
+    // Cipher init failed
+    return WebCryptoCipherStatus::FAILED;
+  }
+
+  int out_len = 0;
+  int final_len = 0;
+  if (!EVP_CipherUpdate(
+          ctx.get(),
+          out,
+          &out_len,
+          params.data.data<unsigned char>(),
+          params.data.size())) {
+    return WebCryptoCipherStatus::FAILED;
+  }
+
+  if (!EVP_CipherFinal_ex(ctx.get(), out + out_len, &final_len))
+    return WebCryptoCipherStatus::FAILED;
+
+  out_len += final_len;
+  if (static_cast<unsigned>(out_len) != params.data.size())
+    return WebCryptoCipherStatus::FAILED;
+
+  return WebCryptoCipherStatus::OK;
+}
+
+WebCryptoCipherStatus AES_CTR_Cipher(
+    const AESCipherConfig& params,
+    ByteSource* out) {
+  BignumPointer num_counters(BN_new());
+  if (!BN_lshift(num_counters.get(), BN_value_one(), params.length))
+    return WebCryptoCipherStatus::FAILED;
+
+  BignumPointer current_counter = GetCounter(params);
+
+  BignumPointer num_output(BN_new());
+
+  if (!BN_set_word(num_output.get(), CeilDiv(params.data.size(), kAesBlockSize)))
+    return WebCryptoCipherStatus::FAILED;
+
+  // Just like in chromium's implementation, if the counter will
+  // be incremented more than there are counter values, we fail.
+  if (BN_cmp(num_output.get(), num_counters.get()) > 0)
+    return WebCryptoCipherStatus::FAILED;
+
+  BignumPointer remaining_until_reset(BN_new());
+  if (!BN_sub(remaining_until_reset.get(),
+              num_counters.get(),
+              current_counter.get())) {
+    return WebCryptoCipherStatus::FAILED;
+  }
+
+  // Output size is identical to the input size.
+  ByteSource::Builder buf(params.data.size());
+
+  // Also just like in chromium's implementation, if we can process
+  // the input without wrapping the counter, we'll do it as a single
+  // call here. If we can't, we'll fallback to the a two-step approach
+  if (BN_cmp(remaining_until_reset.get(), num_output.get()) >= 0) {
+    auto status = AES_CTR_Cipher2(params,
+                                  params.data,
+                                  params.iv.data<unsigned char>(),
+                                  buf.data<unsigned char>());
+    if (status == WebCryptoCipherStatus::OK) *out = std::move(buf).release();
+    return status;
+  }
+
+  BN_ULONG blocks_part1 = BN_get_word(remaining_until_reset.get());
+  BN_ULONG input_size_part1 = blocks_part1 * kAesBlockSize;
+
+  // Encrypt the first part...
+  auto status =
+      AES_CTR_Cipher2(params,
+                      ByteSource::Foreign(params.data.data<char>(), input_size_part1),
+                      params.iv.data<unsigned char>(),
+                      buf.data<unsigned char>());
+
+  if (status != WebCryptoCipherStatus::OK)
+    return status;
+
+  // Wrap the counter around to zero
+  std::vector<unsigned char> new_counter_block = BlockWithZeroedCounter(params);
+
+  // Encrypt the second part...
+  status =
+      AES_CTR_Cipher2(params,
+                      ByteSource::Foreign(params.data.data<char>() + input_size_part1,
+                                          params.data.size() - input_size_part1),
+                      new_counter_block.data(),
+                      buf.data<unsigned char>() + input_size_part1);
+
+  if (status == WebCryptoCipherStatus::OK) *out = std::move(buf).release();
+
+  return status;
+}
+
+ByteSource GetByteSourceFromJS(jsi::Runtime &rt,
+                               const jsi::Value &value,
+                               std::string name) {
+    if (!value.isObject() || !value.asObject(rt).isArrayBuffer(rt)) {
+    throw jsi::JSError(rt, "arg is not an array buffer: " + name);
+  }
+  ByteSource data = ByteSource::FromStringOrBuffer(rt, value);
+  if (data.size() > INT_MAX) {
+    throw jsi::JSError(rt, "arg is too big (> int32): " + name);
+  }
+  return std::move(data);
+}
+
+bool ValidateIV(
+    jsi::Runtime &rt,
+    const jsi::Value &value,
+    AESCipherConfig *params) {
+  params->iv = GetByteSourceFromJS(rt, value, "iv");
+  return true;
+}
+
+bool ValidateCounter(
+  jsi::Runtime &rt,
+  const jsi::Value &value,
+  AESCipherConfig* params) {
+  CHECK(CheckIsUint32(value));  // Length
+  params->length = (uint32_t)value.asNumber();
+  if (params->iv.size() != 16 ||
+      params->length == 0 ||
+      params->length > 128) {
+    throw std::runtime_error("Invalid counter (AES)");
+    return false;
+  }
+  return true;
+}
+
+bool ValidateAuthTag(
+    jsi::Runtime &rt,
+    AESCipherConfig::Mode cipher_mode,
+    const jsi::Value &value,
+    AESCipherConfig *params) {
+  ByteSource tag = GetByteSourceFromJS(rt, value, "tag");
+  switch (cipher_mode) {
+    case AESCipherConfig::Mode::kDecrypt: {
+      params->tag = std::move(tag);
+      break;
+    }
+    case AESCipherConfig::Mode::kEncrypt: {
+      CHECK(CheckIsUint32(value)); // Length
+      params->length = tag.size();
+      if (params->length > 128) {
+        throw std::runtime_error("Invalid tag length (AES)");
+        return false;
+      }
+      break;
+    }
+    default:
+      throw std::runtime_error("Unreachable code in ValidateAuthTag (AES)");
+  }
+  return true;
+}
+
+bool ValidateAdditionalData(
+    jsi::Runtime &rt,
+    const jsi::Value &value,
+    AESCipherConfig *params) {
+  // Additional Data
+  params->additional_data = GetByteSourceFromJS(rt, value, "additional_data");
+  return true;
+}
+
+void UseDefaultIV(AESCipherConfig* params) {
+  params->iv = ByteSource::Foreign(kDefaultWrapIV, strlen(kDefaultWrapIV));
+}
+
+}  // namespace
+
+AESCipher::AESCipher() {}
+
+AESCipherConfig AESCipher::GetParamsFromJS(jsi::Runtime &rt,
+                                          const jsi::Value *args) {
+  AESCipherConfig params;
+  unsigned int offset = 0;
+
+  // mode (encrypt/decrypt)
+  AESCipherConfig::Mode mode =
+    static_cast<AESCipherConfig::Mode>(args[offset].getNumber());
+  params.mode = mode;
+  offset++;
+
+  // key (handle)
+  std::shared_ptr<KeyObjectHandle> handle =
+    std::static_pointer_cast<KeyObjectHandle>(
+      args[offset].asObject(rt).getHostObject(rt));
+  params.key = handle->Data();
+
+  // data
+  params.data = GetByteSourceFromJS(rt, args[offset], "data");
+  offset++;
+
+  // AES Key Variant
+  if (CheckIsInt32(args[offset])) {
+    params.variant = static_cast<AESKeyVariant>(args[offset].asNumber());
+  }
+  offset++;
+
+  // cipher
+  int cipher_nid;
+
+  switch (params.variant) {
+    case kKeyVariantAES_CTR_128:
+      if (!ValidateIV(rt, args[offset + 1], &params) ||
+          !ValidateCounter(rt, args[offset + 2], &params)) {
+        return params;
+      }
+      cipher_nid = NID_aes_128_ctr;
+      break;
+    case kKeyVariantAES_CTR_192:
+      if (!ValidateIV(rt, args[offset + 1], &params) ||
+          !ValidateCounter(rt, args[offset + 2], &params)) {
+        return params;
+      }
+      cipher_nid = NID_aes_192_ctr;
+      break;
+    case kKeyVariantAES_CTR_256:
+      if (!ValidateIV(rt, args[offset + 1], &params) ||
+          !ValidateCounter(rt, args[offset + 2], &params)) {
+        return params;
+      }
+      cipher_nid = NID_aes_256_ctr;
+      break;
+    case kKeyVariantAES_CBC_128:
+      if (!ValidateIV(rt, args[offset + 1], &params))
+        return params;
+      cipher_nid = NID_aes_128_cbc;
+      break;
+    case kKeyVariantAES_CBC_192:
+      if (!ValidateIV(rt, args[offset + 1], &params))
+        return params;
+      cipher_nid = NID_aes_192_cbc;
+      break;
+    case kKeyVariantAES_CBC_256:
+      if (!ValidateIV(rt, args[offset + 1], &params))
+        return params;
+      cipher_nid = NID_aes_256_cbc;
+      break;
+    case kKeyVariantAES_KW_128:
+      UseDefaultIV(&params);
+      cipher_nid = NID_id_aes128_wrap;
+      break;
+    case kKeyVariantAES_KW_192:
+      UseDefaultIV(&params);
+      cipher_nid = NID_id_aes192_wrap;
+      break;
+    case kKeyVariantAES_KW_256:
+      UseDefaultIV(&params);
+      cipher_nid = NID_id_aes256_wrap;
+      break;
+    case kKeyVariantAES_GCM_128:
+      if (!ValidateIV(rt, args[offset + 1], &params) ||
+          !ValidateAuthTag(rt, mode, args[offset + 2], &params) ||
+          !ValidateAdditionalData(rt, args[offset + 3], &params)) {
+        return params;
+      }
+      cipher_nid = NID_aes_128_gcm;
+      break;
+    case kKeyVariantAES_GCM_192:
+      if (!ValidateIV(rt, args[offset + 1], &params) ||
+          !ValidateAuthTag(rt, mode, args[offset + 2], &params) ||
+          !ValidateAdditionalData(rt, args[offset + 3], &params)) {
+        return params;
+      }
+      cipher_nid = NID_aes_192_gcm;
+      break;
+    case kKeyVariantAES_GCM_256:
+      if (!ValidateIV(rt, args[offset + 1], &params) ||
+          !ValidateAuthTag(rt, mode, args[offset + 2], &params) ||
+          !ValidateAdditionalData(rt, args[offset + 3], &params)) {
+        return params;
+      }
+      cipher_nid = NID_aes_256_gcm;
+      break;
+    default:
+      throw std::runtime_error("Unreachable code in GetParamsFromJS (AES)");
+  }
+
+  params.cipher = EVP_get_cipherbynid(cipher_nid);
+  if (params.cipher == nullptr) {
+    throw std::runtime_error("Unknown cipher (AES)");
+    return params;
+  }
+
+  if (params.iv.size() <
+      static_cast<size_t>(EVP_CIPHER_iv_length(params.cipher))) {
+    throw std::runtime_error("Invalid IV length (AES)");
+    return params;
+  }
+
+  return params;
+}
+
+WebCryptoCipherStatus AESCipher::DoCipher(const AESCipherConfig &params,
+                                          ByteSource* out) {
+#define V(name, fn)                                                           \
+  case kKeyVariantAES_ ## name:                                               \
+    return fn(params, out);
+  switch (params.variant) {
+    VARIANTS(V)
+    default:
+      throw std::runtime_error("Unreachable code in DoCipher (AES)");
+  }
+#undef V
+}
+
+} // namespace margelo

--- a/cpp/webcrypto/crypto_aes.h
+++ b/cpp/webcrypto/crypto_aes.h
@@ -77,7 +77,7 @@ class AESCipher {
  public:
   AESCipher() {}
   AESCipherConfig GetParamsFromJS(jsi::Runtime &rt, const jsi::Value *args);
-  WebCryptoCipherStatus DoCipher(const AESCipherConfig &params, ByteSource* out);
+  WebCryptoCipherStatus DoCipher(const AESCipherConfig &params, ByteSource *out);
 };
 
 }  // namespace margelo

--- a/cpp/webcrypto/crypto_aes.h
+++ b/cpp/webcrypto/crypto_aes.h
@@ -1,0 +1,85 @@
+#ifndef crypto_aes_h
+#define crypto_aes_h
+
+#include <jsi/jsi.h>
+
+#include "MGLKeys.h"
+#ifdef ANDROID
+#include "Utils/MGLUtils.h"
+#else
+#include "MGLUtils.h"
+#endif
+
+namespace margelo {
+
+namespace jsi = facebook::jsi;
+
+constexpr size_t kAesBlockSize = 16;
+constexpr unsigned kNoAuthTagLength = static_cast<unsigned>(-1);
+constexpr const char* kDefaultWrapIV = "\xa6\xa6\xa6\xa6\xa6\xa6\xa6\xa6";
+
+#define VARIANTS(V)                                                           \
+  V(CTR_128, AES_CTR_Cipher)                                                  \
+  V(CTR_192, AES_CTR_Cipher)                                                  \
+  V(CTR_256, AES_CTR_Cipher)                                                  \
+  V(CBC_128, AES_Cipher)                                                      \
+  V(CBC_192, AES_Cipher)                                                      \
+  V(CBC_256, AES_Cipher)                                                      \
+  V(GCM_128, AES_Cipher)                                                      \
+  V(GCM_192, AES_Cipher)                                                      \
+  V(GCM_256, AES_Cipher)                                                      \
+  V(KW_128, AES_Cipher)                                                       \
+  V(KW_192, AES_Cipher)                                                       \
+  V(KW_256, AES_Cipher)
+
+enum AESKeyVariant {
+#define V(name, _) kKeyVariantAES_ ## name,
+  VARIANTS(V)
+#undef V
+};
+
+enum class WebCryptoCipherStatus {
+  OK,
+  INVALID_KEY_TYPE,
+  FAILED
+};
+
+struct AESCipherConfig final {
+    enum Mode {
+    kEncrypt,
+    kDecrypt,
+    // kWrapKey,
+    // kUnwrapKey,
+  };
+
+  Mode mode;
+  AESKeyVariant variant;
+  std::shared_ptr<KeyObjectData> key; // TODO: ManagedEVPPKey?
+  ByteSource data;
+  const EVP_CIPHER* cipher;
+  size_t length;
+  ByteSource iv;  // Used for both iv or counter
+  ByteSource additional_data;
+  ByteSource tag;  // Used only for authenticated modes (GCM)
+
+  AESCipherConfig() = default;
+
+  // AESCipherConfig(AESCipherConfig&& other) noexcept;
+
+  // AESCipherConfig& operator=(AESCipherConfig&& other) noexcept;
+
+  // void MemoryInfo(MemoryTracker* tracker) const override;
+  // SET_MEMORY_INFO_NAME(AESCipherConfig)
+  // SET_SELF_SIZE(AESCipherConfig)
+};
+
+class AESCipher {
+ public:
+  AESCipher() {}
+  AESCipherConfig GetParamsFromJS(jsi::Runtime &rt, const jsi::Value *args);
+  WebCryptoCipherStatus DoCipher(const AESCipherConfig &params, ByteSource* out);
+};
+
+}  // namespace margelo
+
+#endif  // crypto_aes_h

--- a/cpp/webcrypto/crypto_aes.h
+++ b/cpp/webcrypto/crypto_aes.h
@@ -54,7 +54,7 @@ struct AESCipherConfig final {
 
   Mode mode;
   AESKeyVariant variant;
-  std::shared_ptr<KeyObjectData> key; // TODO: ManagedEVPPKey?
+  std::shared_ptr<KeyObjectData> key;
   ByteSource data;
   const EVP_CIPHER* cipher;
   ByteSource iv;  // Used for both iv or counter

--- a/cpp/webcrypto/crypto_aes.h
+++ b/cpp/webcrypto/crypto_aes.h
@@ -57,10 +57,10 @@ struct AESCipherConfig final {
   std::shared_ptr<KeyObjectData> key; // TODO: ManagedEVPPKey?
   ByteSource data;
   const EVP_CIPHER* cipher;
-  size_t length;
   ByteSource iv;  // Used for both iv or counter
-  ByteSource additional_data;
+  size_t length;
   ByteSource tag;  // Used only for authenticated modes (GCM)
+  ByteSource additional_data;
 
   AESCipherConfig() = default;
 

--- a/cpp/webcrypto/crypto_keygen.cpp
+++ b/cpp/webcrypto/crypto_keygen.cpp
@@ -1,0 +1,53 @@
+#include "crypto_keygen.h"
+
+#ifdef ANDROID
+#include "JSIUtils/MGLJSIMacros.h"
+#include "Utils/MGLUtils.h"
+#else
+#include "MGLJSIUtils.h"
+#include "MGLUtils.h"
+#endif
+
+namespace margelo {
+
+  jsi::Value SecretKeyGen::DoKeyGen(jsi::Runtime &rt, const jsi::Value *args) {
+    auto skg = new SecretKeyGen(FnMode::kAsync);
+    CHECK(skg->getParamsFromJS(rt, args));
+    CHECK(skg->doKeyGen());
+    return toJSI(rt, std::move(skg->getKey()));
+  }
+
+  jsi::Value SecretKeyGen::DoKeyGenSync(jsi::Runtime &rt, const jsi::Value *args) {
+    auto skg = new SecretKeyGen(FnMode::kSync);
+    CHECK(skg->getParamsFromJS(rt, args));
+    CHECK(skg->doKeyGen());
+    return toJSI(rt, std::move(skg->getKey()));
+  }
+
+  bool SecretKeyGen::getParamsFromJS(jsi::Runtime &rt, const jsi::Value *args) {
+    SecretKeyGenConfig params;
+    unsigned int offset = 0;
+
+    // length
+    CHECK(CheckIsUint32(args[offset]));
+    uint32_t bits = (uint32_t)args[offset].asNumber();
+    params.length = bits / CHAR_BIT;
+
+    this->params_ = std::move(params);
+    return true;
+  }
+
+  bool SecretKeyGen::doKeyGen() {
+    // TODO: threading / async here, as we don't have jsi::Runtime
+    ByteSource::Builder bytes(this->params_.length);
+    if (CSPRNG(bytes.data<unsigned char>(), this->params_.length).is_err())
+      return false;
+    this->key_ = std::move(bytes).release();
+    return true;
+  }
+
+  ByteSource SecretKeyGen::getKey() {
+    return std::move(this->key_);
+  }
+
+} // namespace margelo

--- a/cpp/webcrypto/crypto_keygen.cpp
+++ b/cpp/webcrypto/crypto_keygen.cpp
@@ -12,48 +12,75 @@
 
 namespace margelo {
 
-  jsi::Value SecretKeyGen::DoKeyGen(jsi::Runtime &rt, const jsi::Value *args) {
-    auto skg = new SecretKeyGen(FnMode::kAsync);
-    CHECK(skg->getParamsFromJS(rt, args));
-    CHECK(skg->doKeyGen());
-    auto out = jsi::Object::createFromHostObject(rt, skg->getHandle());
-    return jsi::Value(std::move(out));
-  }
+FieldDefinition GenerateSecretKeyFieldDefinition(
+    std::shared_ptr<react::CallInvoker> jsCallInvoker,
+    std::shared_ptr<DispatchQueue::dispatch_queue> workerQueue) {
+  return buildPair(
+      "generateSecretKey", JSIF([=]) {
+    auto skg = new SecretKeyGen();
+    CHECK(skg->GetParamsFromJS(runtime, arguments));
+    // make and return a promise
+    auto promiseConstructor = runtime.global().getPropertyAsFunction(runtime, "Promise");
+    auto promise = promiseConstructor.callAsConstructor(
+        runtime,
+        jsi::Function::createFromHostFunction(
+            runtime,
+            jsi::PropNameID::forAscii(runtime, "executor"),
+            2,
+            [&jsCallInvoker, skg](
+                jsi::Runtime &runtime, const jsi::Value &,
+                const jsi::Value *promiseArgs, size_t) -> jsi::Value {
+              auto resolve = std::make_shared<jsi::Value>(runtime, promiseArgs[0]);
+              auto reject = std::make_shared<jsi::Value>(runtime, promiseArgs[1]);
+              try {
+                jsCallInvoker->invokeAsync([&runtime, resolve, skg]() {
+                  if (skg->DoKeyGen()) {
+                    auto res = jsi::Object::createFromHostObject(runtime, skg->GetHandle());
+                    resolve->asObject(runtime).asFunction(runtime).call(runtime, std::move(res));
+                  } else {
+                    throw std::runtime_error("Error generating key");
+                  }
+                });
+              } catch (std::exception e) {
+                jsCallInvoker->invokeAsync([&runtime, reject, e]() {
+                  auto res = jsi::String::createFromUtf8(runtime, e.what());
+                  reject->asObject(runtime).asFunction(runtime).call(runtime, std::move(res));
+                });
+              }
+              return {};
+            }
+        )
+    );
+    return promise;
+  });
+};
 
-  jsi::Value SecretKeyGen::DoKeyGenSync(jsi::Runtime &rt, const jsi::Value *args) {
-    auto skg = new SecretKeyGen(FnMode::kSync);
-    CHECK(skg->getParamsFromJS(rt, args));
-    CHECK(skg->doKeyGen());
-    auto out = jsi::Object::createFromHostObject(rt, skg->getHandle());
-    return jsi::Value(std::move(out));
-  }
+bool SecretKeyGen::GetParamsFromJS(jsi::Runtime &rt, const jsi::Value *args) {
+  SecretKeyGenConfig params;
+  unsigned int offset = 0;
 
-  bool SecretKeyGen::getParamsFromJS(jsi::Runtime &rt, const jsi::Value *args) {
-    SecretKeyGenConfig params;
-    unsigned int offset = 0;
+  // length
+  CHECK(CheckIsUint32(args[offset]));
+  uint32_t bits = (uint32_t)args[offset].asNumber();
+  params.length = bits / CHAR_BIT;
 
-    // length
-    CHECK(CheckIsUint32(args[offset]));
-    uint32_t bits = (uint32_t)args[offset].asNumber();
-    params.length = bits / CHAR_BIT;
+  this->params_ = std::move(params);
+  return true;
+}
 
-    this->params_ = std::move(params);
-    return true;
-  }
+bool SecretKeyGen::DoKeyGen() {
+  // TODO: threading / async here, as we don't have jsi::Runtime
+  ByteSource::Builder bytes(this->params_.length);
+  if (CSPRNG(bytes.data<unsigned char>(), this->params_.length).is_err())
+    return false;
+  auto key_data = std::move(bytes).release();
+  this->key_ = KeyObjectData::CreateSecret(std::move(key_data));
+  return true;
+}
 
-  bool SecretKeyGen::doKeyGen() {
-    // TODO: threading / async here, as we don't have jsi::Runtime
-    ByteSource::Builder bytes(this->params_.length);
-    if (CSPRNG(bytes.data<unsigned char>(), this->params_.length).is_err())
-      return false;
-    auto key_data = std::move(bytes).release();
-    this->key_ = KeyObjectData::CreateSecret(std::move(key_data));
-    return true;
-  }
-
-  std::shared_ptr<KeyObjectHandle> SecretKeyGen::getHandle() {
-    auto handle = KeyObjectHandle::Create(this->key_);
-    return handle;
-  }
+std::shared_ptr<KeyObjectHandle> SecretKeyGen::GetHandle() {
+  auto handle = KeyObjectHandle::Create(this->key_);
+  return handle;
+}
 
 } // namespace margelo

--- a/cpp/webcrypto/crypto_keygen.h
+++ b/cpp/webcrypto/crypto_keygen.h
@@ -1,0 +1,45 @@
+#ifndef crypto_keygen_h
+#define crypto_keygen_h
+
+#include <jsi/jsi.h>
+
+#include "MGLKeys.h"
+#ifdef ANDROID
+#include "Utils/MGLUtils.h"
+#else
+#include "MGLUtils.h"
+#endif
+
+namespace margelo
+{
+
+  namespace jsi = facebook::jsi;
+
+  struct SecretKeyGenConfig {
+    size_t length;  // In bytes.
+    ByteSource out; // Placeholder for the generated key bytes.
+
+    SecretKeyGenConfig() = default;
+  };
+
+  class SecretKeyGen {
+   public:
+    static jsi::Value DoKeyGen(jsi::Runtime &rt, const jsi::Value *args);
+    static jsi::Value DoKeyGenSync(jsi::Runtime &rt, const jsi::Value *args);
+    inline SecretKeyGen(FnMode mode) {
+      this->setMode(mode);
+    }
+   private:
+    inline void setMode(FnMode mode) { mode_ = mode; };
+    bool getParamsFromJS(jsi::Runtime &rt, const jsi::Value *args);
+    bool doKeyGen();
+    ByteSource getKey();
+
+    FnMode mode_;
+    SecretKeyGenConfig params_;
+    ByteSource key_;
+  };
+
+} // namespace margelo
+
+#endif // crypto_keygen_h

--- a/cpp/webcrypto/crypto_keygen.h
+++ b/cpp/webcrypto/crypto_keygen.h
@@ -16,8 +16,7 @@ namespace margelo
   namespace jsi = facebook::jsi;
 
   struct SecretKeyGenConfig {
-    size_t length;  // In bytes.
-    ByteSource out; // Placeholder for the generated key bytes.
+    size_t length;  // in bytes
 
     SecretKeyGenConfig() = default;
   };
@@ -33,11 +32,11 @@ namespace margelo
     inline void setMode(FnMode mode) { mode_ = mode; };
     bool getParamsFromJS(jsi::Runtime &rt, const jsi::Value *args);
     bool doKeyGen();
-    ByteSource getKey();
+    std::shared_ptr<KeyObjectHandle> getHandle();
 
     FnMode mode_;
     SecretKeyGenConfig params_;
-    ByteSource key_;
+    std::shared_ptr<KeyObjectData> key_;
   };
 
 } // namespace margelo

--- a/cpp/webcrypto/crypto_keygen.h
+++ b/cpp/webcrypto/crypto_keygen.h
@@ -10,34 +10,28 @@
 #include "MGLUtils.h"
 #endif
 
-namespace margelo
-{
+namespace margelo {
 
-  namespace jsi = facebook::jsi;
+namespace jsi = facebook::jsi;
 
-  struct SecretKeyGenConfig {
-    size_t length;  // in bytes
+FieldDefinition GenerateSecretKeyFieldDefinition(
+    std::shared_ptr<react::CallInvoker> jsCallInvoker,
+    std::shared_ptr<DispatchQueue::dispatch_queue> workerQueue);
 
-    SecretKeyGenConfig() = default;
-  };
+struct SecretKeyGenConfig {
+  size_t length;  // in bytes
+  SecretKeyGenConfig() = default;
+};
 
-  class SecretKeyGen {
-   public:
-    static jsi::Value DoKeyGen(jsi::Runtime &rt, const jsi::Value *args);
-    static jsi::Value DoKeyGenSync(jsi::Runtime &rt, const jsi::Value *args);
-    inline SecretKeyGen(FnMode mode) {
-      this->setMode(mode);
-    }
-   private:
-    inline void setMode(FnMode mode) { mode_ = mode; };
-    bool getParamsFromJS(jsi::Runtime &rt, const jsi::Value *args);
-    bool doKeyGen();
-    std::shared_ptr<KeyObjectHandle> getHandle();
-
-    FnMode mode_;
-    SecretKeyGenConfig params_;
-    std::shared_ptr<KeyObjectData> key_;
-  };
+class SecretKeyGen {
+  public:
+  bool GetParamsFromJS(jsi::Runtime &rt, const jsi::Value *args);
+  bool DoKeyGen();
+  std::shared_ptr<KeyObjectHandle> GetHandle();
+  private:
+  SecretKeyGenConfig params_;
+  std::shared_ptr<KeyObjectData> key_;
+};
 
 } // namespace margelo
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -323,7 +323,7 @@ PODS:
   - react-native-quick-base64 (2.1.2):
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
-  - react-native-quick-crypto (0.7.0-rc.10):
+  - react-native-quick-crypto (0.7.0):
     - OpenSSL-Universal
     - RCT-Folly (= 2021.07.22.00)
     - React
@@ -627,7 +627,7 @@ SPEC CHECKSUMS:
   React-logger: 8edc785c47c8686c7962199a307015e2ce9a0e4f
   react-native-fast-encoder: 6f59e9b08e2bc5a8bf1f36e1630cdcfd66dd18af
   react-native-quick-base64: 61228d753294ae643294a75fece8e0e80b7558a6
-  react-native-quick-crypto: 197e2711a814fd71f294533139c56b5ebc497e65
+  react-native-quick-crypto: b2139cd8277ae73b333b790a08d70bb25bb3550e
   react-native-safe-area-context: 2cd91d532de12acdb0a9cbc8d43ac72a8e4c897c
   React-NativeModulesApple: b6868ee904013a7923128892ee4a032498a1024a
   React-perflogger: 31ea61077185eb1428baf60c0db6e2886f141a5a

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -323,7 +323,7 @@ PODS:
   - react-native-quick-base64 (2.1.2):
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
-  - react-native-quick-crypto (0.7.0-rc.9):
+  - react-native-quick-crypto (0.7.0-rc.10):
     - OpenSSL-Universal
     - RCT-Folly (= 2021.07.22.00)
     - React
@@ -627,7 +627,7 @@ SPEC CHECKSUMS:
   React-logger: 8edc785c47c8686c7962199a307015e2ce9a0e4f
   react-native-fast-encoder: 6f59e9b08e2bc5a8bf1f36e1630cdcfd66dd18af
   react-native-quick-base64: 61228d753294ae643294a75fece8e0e80b7558a6
-  react-native-quick-crypto: 8e4521904e2b9da9454bcd825e9c198a1efb3f29
+  react-native-quick-crypto: 197e2711a814fd71f294533139c56b5ebc497e65
   react-native-safe-area-context: 2cd91d532de12acdb0a9cbc8d43ac72a8e4c897c
   React-NativeModulesApple: b6868ee904013a7923128892ee4a032498a1024a
   React-perflogger: 31ea61077185eb1428baf60c0db6e2886f141a5a

--- a/example/src/components/TestItem.tsx
+++ b/example/src/components/TestItem.tsx
@@ -74,7 +74,6 @@ export const TestItem: React.FC<TestItemProps> = ({
 const styles = StyleSheet.create({
   container: {
     width: '100%',
-    paddingVertical: 2,
     flexDirection: 'row',
     alignContent: 'center',
     alignItems: 'center',
@@ -84,7 +83,7 @@ const styles = StyleSheet.create({
     borderBottomColor: '#ccc',
   },
   checkbox: {
-    transform: [{ scaleX: 0.8 }, { scaleY: 0.8 }],
+    transform: [{ scaleX: 0.7 }, { scaleY: 0.7 }],
   },
   label: {
     fontSize: 12,

--- a/example/src/hooks/useTestList.ts
+++ b/example/src/hooks/useTestList.ts
@@ -18,6 +18,7 @@ import '../testing/Tests/SmokeTests/bundlerTests';
 import '../testing/Tests/webcryptoTests/deriveBits';
 import '../testing/Tests/webcryptoTests/digest';
 import '../testing/Tests/webcryptoTests/generateKey';
+import '../testing/Tests/webcryptoTests/encrypt_decrypt';
 import '../testing/Tests/webcryptoTests/import_export';
 import '../testing/Tests/webcryptoTests/sign_verify';
 

--- a/example/src/hooks/useTestList.ts
+++ b/example/src/hooks/useTestList.ts
@@ -11,6 +11,7 @@ import '../testing/Tests/HashTests/HashTests';
 import '../testing/Tests/CipherTests/CipherTestFirst';
 import '../testing/Tests/CipherTests/CipherTestSecond';
 import '../testing/Tests/CipherTests/PublicCipherTests';
+import '../testing/Tests/CipherTests/generateKey';
 import '../testing/Tests/CipherTests/GenerateKeyPairTests';
 import '../testing/Tests/ConstantsTests/ConstantsTests';
 import '../testing/Tests/SignTests/SignTests';

--- a/example/src/testing/MochaRNAdapter.ts
+++ b/example/src/testing/MochaRNAdapter.ts
@@ -1,6 +1,12 @@
 import 'mocha';
 import type * as MochaTypes from 'mocha';
 
+// polyfill encoders for all tests
+// @ts-expect-error
+import { polyfillGlobal } from 'react-native/Libraries/Utilities/PolyfillFunctions';
+import RNFE from 'react-native-fast-encoder';
+polyfillGlobal('TextEncoder', () => RNFE);
+
 export const rootSuite = new Mocha.Suite('') as MochaTypes.Suite;
 rootSuite.timeout(10 * 1000);
 

--- a/example/src/testing/Tests/CipherTests/generateKey.ts
+++ b/example/src/testing/Tests/CipherTests/generateKey.ts
@@ -1,0 +1,116 @@
+// from https://github.com/nodejs/node/blob/main/test/parallel/test-crypto-secret-keygen.js
+
+import { expect } from 'chai';
+import crypto from 'react-native-quick-crypto';
+import { describe, it } from '../../MochaRNAdapter';
+import type { AESLength } from '../../../../../src/keys';
+
+const { generateKey, generateKeySync } = crypto;
+
+describe('generateKey', () => {
+  const badTypes = [1, true, [], {}, Infinity, null, undefined];
+  badTypes.forEach((badType) => {
+    it(`bad type input: ${badType}`, async () => {
+      // @ts-expect-error
+      expect(() => generateKey(badType, 1, () => {})).to.throw(
+        'Unsupported key type'
+      );
+
+      // @ts-expect-error
+      expect(() => generateKeySync(badType, 1)).to.throw(
+        'Unsupported key type'
+      );
+    });
+  });
+
+  const badOptionsAES = ['', true, [], null, undefined];
+  badOptionsAES.forEach((badOption) => {
+    it(`bad option input (aes): ${badOption}`, async () => {
+      const expected =
+        badOption !== null && badOption !== undefined
+          ? 'AES key length must be 128, 192, or 256 bits'
+          : "Cannot read property 'length' of " + badOption;
+
+      // @ts-expect-error
+      expect(() => generateKey('aes', badOption, () => {})).to.throw(expected);
+      // @ts-expect-error
+      expect(() => generateKeySync('aes', badOption)).to.throw(expected);
+    });
+  });
+
+  // const badOptionsHMAC = ['', true, [], null, undefined];
+  // badOptionsHMAC.forEach((badOption) => {
+  //   it(`bad option input (hmac): ${badOption}`, async () => {
+  //     if (badOption !== null && badOption !== undefined) {
+  //       // @ts-expect-error
+  //       expect(() => generateKey('hmac', badOption, () => {})).to.throw(
+  //         'HMAC key length must be between 8 and 2^31 - 1'
+  //       );
+  //       // @ts-expect-error
+  //       expect(() => generateKeySync('hmac', badOption)).to.throw(
+  //         'HMAC key length must be between 8 and 2^31 - 1'
+  //       );
+  //     } else {
+  //       // @ts-expect-error
+  //       expect(() => generateKey('hmac', badOption, () => {})).to.throw(
+  //         `Cannot read property 'length' of ${badOption}`
+  //       );
+  //       // @ts-expect-error
+  //       expect(() => generateKeySync('hmac', badOption)).to.throw(
+  //         `Cannot read property 'length' of ${badOption}`
+  //       );
+  //     }
+  //   });
+  // });
+
+  it('bad callback (aes)', async () => {
+    // @ts-expect-error
+    expect(() => generateKey('aes', { length: 256 })).to.throw(
+      'Callback is not a function'
+    );
+  });
+
+  const hmacBadLengths = [-1, 4, 7, 2 ** 31];
+  hmacBadLengths.forEach((badLength) => {
+    it(`bad option length (hmac): ${badLength}`, async () => {
+      expect(() =>
+        // @ts-expect-error
+        generateKey('hmac', { length: badLength }, () => {})
+      ).to.throw('HMAC key length must be between 8 and 2^31 - 1');
+      // @ts-expect-error
+      expect(() => generateKeySync('hmac', { length: badLength })).to.throw(
+        'HMAC key length must be between 8 and 2^31 - 1'
+      );
+    });
+  });
+
+  const aesLengths: AESLength[] = [128, 192, 256];
+  aesLengths.forEach((length) => {
+    it(`happy generateKeySync (aes): ${length}`, async () => {
+      const key = generateKeySync('aes', { length });
+      expect(key).to.not.be.undefined;
+      const keybuf = key.export();
+      expect(keybuf.byteLength).to.equal(length / 8);
+    });
+    it(`happy generateKey (aes): ${length}`, async () => {
+      generateKey('aes', { length }, (err, key) => {
+        expect(err).to.be.undefined;
+        expect(key).to.not.be.undefined;
+        const keybuf = key?.export();
+        expect(keybuf?.byteLength).to.equal(length / 8);
+      });
+    });
+  });
+
+  // TODO: copied from node, no edits yet - fix when we implement HMAC
+  // const key = generateKeySync('hmac', { length: 123 });
+  // assert(key);
+  // const keybuf = key.export();
+  // assert.strictEqual(keybuf.byteLength, Math.floor(123 / 8));
+
+  // generateKey('hmac', { length: 123 }, common.mustSucceed((key) => {
+  //   assert(key);
+  //   const keybuf = key.export();
+  //   assert.strictEqual(keybuf.byteLength, Math.floor(123 / 8));
+  // }));
+});

--- a/example/src/testing/Tests/util.ts
+++ b/example/src/testing/Tests/util.ts
@@ -15,3 +15,11 @@ export const assertThrowsAsync = async (fn: any, expectedMessage: string) => {
   }
   assert.fail('function did not throw as expected');
 };
+
+export const decodeHex = (str: string): Uint8Array => {
+  const uint8array = new Uint8Array(Math.ceil(str.length / 2));
+  for (let i = 0; i < str.length; ) {
+    uint8array[i / 2] = Number.parseInt(str.slice(i, (i += 2)), 16);
+  }
+  return uint8array;
+};

--- a/example/src/testing/Tests/webcryptoTests/encrypt_decrypt.ts
+++ b/example/src/testing/Tests/webcryptoTests/encrypt_decrypt.ts
@@ -1,13 +1,35 @@
 import crypto from 'react-native-quick-crypto';
 import { describe, it } from '../../MochaRNAdapter';
 import { expect } from 'chai';
+import type {
+  AesCbcParams,
+  AesCtrParams,
+  AesGcmParams,
+  AnyAlgorithm,
+  CryptoKey,
+  EncryptDecryptParams,
+} from '../../../../../src/keys';
+import aes_cbc_fixtures from '../../fixtures/aes_cbc';
+import aes_ctr_fixtures from '../../fixtures/aes_ctr';
+import aes_gcm_fixtures from '../../fixtures/aes_gcm';
+import { assertThrowsAsync } from '../util';
+import { ab2str } from '../../../../../src/Utils';
 
-// polyfill encoders
-// @ts-expect-error
-import { polyfillGlobal } from 'react-native/Libraries/Utilities/PolyfillFunctions';
-import RNFE from 'react-native-fast-encoder';
-import type { CryptoKey } from '../../../../../src/keys';
-polyfillGlobal('TextEncoder', () => RNFE);
+export type AesEncryptDecryptTestVector = {
+  keyBuffer?: ArrayBuffer;
+  algorithm?: EncryptDecryptParams;
+  plaintext?: ArrayBuffer;
+  result?: ArrayBuffer;
+  keyLength?: string;
+};
+
+export type VectorValue = Record<string, ArrayBuffer>;
+export type BadPadding = {
+  zeroPadChar: ArrayBuffer;
+  bigPadChar: ArrayBuffer;
+  inconsistentPadChars: ArrayBuffer;
+};
+export type BadPaddingVectorValue = Record<string, BadPadding>;
 
 const { subtle } = crypto;
 
@@ -15,6 +37,8 @@ const { subtle } = crypto;
 // will provide much greater coverage.
 
 describe('subtle - encrypt / decrypt', () => {
+  // from https://github.com/nodejs/node/blob/main/test/parallel/test-webcrypto-encrypt-decrypt.js
+
   // // Test Encrypt/Decrypt RSA-OAEP
   // {
   //   const buf = crypto.getRandomValues(new Uint8Array(50));
@@ -46,6 +70,10 @@ describe('subtle - encrypt / decrypt', () => {
   //   test().then(common.mustCall());
   // }
 
+  // TODO: when RSA is fully-implemented, add the tests in
+  //  * test-webcrypto-encrypt-decrypt-rsa.js
+
+  // from https://github.com/nodejs/node/blob/main/test/parallel/test-webcrypto-encrypt-decrypt.js
   // Test Encrypt/Decrypt AES-CTR
   {
     const buf = crypto.getRandomValues(new Uint8Array(50));
@@ -157,7 +185,329 @@ describe('subtle - encrypt / decrypt', () => {
     });
   }
 
-  // TODO: when algorithms are fully-implemented, add the tests in
-  //  * test-webcrypto-encrypt-decrypt-aes.js
-  //  * test-webcrypto-encrypt-decrypt-rsa.js
+  // from https://github.com/nodejs/node/blob/main/test/parallel/test-webcrypto-encrypt-decrypt-aes.js
+  async function testEncrypt({
+    keyBuffer,
+    algorithm,
+    plaintext,
+    result,
+  }: AesEncryptDecryptTestVector): Promise<void> {
+    // keeps typescript happy
+    if (!keyBuffer || !algorithm || !plaintext || !result) {
+      throw new Error('Missing test vector');
+    }
+
+    // Using a copy of plaintext to prevent tampering of the original
+    const plaintextBuffer = Buffer.from(plaintext);
+
+    const key = await subtle.importKey(
+      'raw',
+      keyBuffer,
+      { name: algorithm.name },
+      false,
+      ['encrypt', 'decrypt']
+    );
+    const output = await subtle.encrypt(algorithm, key, plaintext);
+    // @ts-expect-error
+    plaintextBuffer[0] = 255 - plaintextBuffer[0];
+
+    expect(ab2str(output)).to.equal(ab2str(result), 'output != result');
+
+    const checkAB = await subtle.decrypt(algorithm, key, output);
+    // Converting the returned ArrayBuffer into a Buffer right away,
+    // so that the next line works
+    const check = Buffer.from(checkAB);
+    // @ts-expect-error
+    check[0] = 255 - check[0];
+
+    expect(ab2str(checkAB)).to.equal(
+      ab2str(plaintextBuffer),
+      'check != plaintext'
+    );
+  }
+
+  async function testEncryptNoEncrypt({
+    keyBuffer,
+    algorithm,
+    plaintext,
+  }: AesEncryptDecryptTestVector): Promise<void> {
+    // keeps typescript happy
+    if (!keyBuffer || !algorithm || !plaintext) {
+      throw new Error('Missing test vector');
+    }
+
+    const key = await subtle.importKey(
+      'raw',
+      keyBuffer,
+      { name: algorithm.name },
+      false,
+      ['decrypt']
+    );
+
+    await assertThrowsAsync(
+      async () => await subtle.encrypt(algorithm, key, plaintext),
+      'The requested operation is not valid for the provided key'
+    );
+  }
+
+  async function testEncryptNoDecrypt({
+    keyBuffer,
+    algorithm,
+    plaintext,
+  }: AesEncryptDecryptTestVector): Promise<void> {
+    // keeps typescript happy
+    if (!keyBuffer || !algorithm || !plaintext) {
+      throw new Error('Missing test vector');
+    }
+
+    const key = await subtle.importKey(
+      'raw',
+      keyBuffer,
+      { name: algorithm.name },
+      false,
+      ['encrypt']
+    );
+
+    const output = await subtle.encrypt(algorithm, key, plaintext);
+
+    await assertThrowsAsync(
+      async () => await subtle.decrypt(algorithm, key, output),
+      'The requested operation is not valid for the provided key'
+    );
+  }
+
+  async function testEncryptWrongAlg(
+    { keyBuffer, algorithm, plaintext }: AesEncryptDecryptTestVector,
+    alg: AnyAlgorithm
+  ): Promise<void> {
+    // keeps typescript happy
+    if (!keyBuffer || !algorithm || !plaintext) {
+      throw new Error('Missing test vector');
+    }
+
+    expect(algorithm.name).to.not.equal(alg);
+    const key = await subtle.importKey('raw', keyBuffer, { name: alg }, false, [
+      'encrypt',
+    ]);
+
+    await assertThrowsAsync(
+      async () => await subtle.encrypt(algorithm, key, plaintext),
+      'The requested operation is not valid for the provided key'
+    );
+  }
+
+  async function testDecrypt({
+    keyBuffer,
+    algorithm,
+    result,
+  }: AesEncryptDecryptTestVector): Promise<void> {
+    // keeps typescript happy
+    if (!keyBuffer || !algorithm || !result) {
+      throw new Error('Missing test vector');
+    }
+
+    const key = await subtle.importKey(
+      'raw',
+      keyBuffer,
+      { name: algorithm.name },
+      false,
+      ['encrypt', 'decrypt']
+    );
+
+    await subtle.decrypt(algorithm, key, result);
+  }
+
+  // Test aes-cbc vectors
+  {
+    let { passing, failing, decryptionFailing } = aes_cbc_fixtures;
+
+    passing.forEach((vector: AesEncryptDecryptTestVector) => {
+      const { algorithm, keyLength } = vector;
+      const { name } = algorithm as AesCbcParams;
+      it(`testEncrypt passing ${name} ${keyLength}`, async () => {
+        await testEncrypt(vector);
+      });
+      it(`testEncryptNoEncrypt passing ${name} ${keyLength}`, async () => {
+        await testEncryptNoEncrypt(vector);
+      });
+      it(`testEncryptNoDecrypt passing ${name} ${keyLength}`, async () => {
+        await testEncryptNoDecrypt(vector);
+      });
+      it(`testEncryptWrongAlg passing ${name} ${keyLength}`, async () => {
+        await testEncryptWrongAlg(vector, 'AES-CTR');
+      });
+    });
+
+    failing.forEach((vector: AesEncryptDecryptTestVector) => {
+      const { algorithm, keyLength } = vector;
+      const { name } = algorithm as AesCbcParams;
+      it(`testEncrypt failing ${name} ${keyLength}`, async () => {
+        await assertThrowsAsync(
+          async () => await testEncrypt(vector),
+          'algorithm.iv must contain exactly 16 bytes'
+        );
+      });
+      it(`testDecrypt failing ${name} ${keyLength}`, async () => {
+        await assertThrowsAsync(
+          async () => await testDecrypt(vector),
+          'algorithm.iv must contain exactly 16 bytes'
+        );
+      });
+    });
+
+    decryptionFailing.forEach((vector: AesEncryptDecryptTestVector) => {
+      const { algorithm, keyLength } = vector;
+      const { name } = algorithm as AesCbcParams;
+      it(`testDecrypt decryptionFailing ${name} ${keyLength}`, async () => {
+        await assertThrowsAsync(
+          async () => await testDecrypt(vector),
+          'error in DoCipher, status: 2'
+        );
+      });
+    });
+  }
+
+  // Test aes-ctr vectors
+  {
+    let { passing, failing, decryptionFailing } = aes_ctr_fixtures;
+
+    passing.forEach((vector: AesEncryptDecryptTestVector) => {
+      const { algorithm, keyLength } = vector;
+      const { name } = algorithm as AesCtrParams;
+      it(`testEncrypt passing ${name} ${keyLength}`, async () => {
+        await testEncrypt(vector);
+      });
+      it(`testEncryptNoEncrypt passing ${name} ${keyLength}`, async () => {
+        await testEncryptNoEncrypt(vector);
+      });
+      it(`testEncryptNoDecrypt passing ${name} ${keyLength}`, async () => {
+        await testEncryptNoDecrypt(vector);
+      });
+      it(`testEncryptWrongAlg passing ${name} ${keyLength}`, async () => {
+        await testEncryptWrongAlg(vector, 'AES-CBC');
+      });
+    });
+
+    // TODO(@jasnell): These fail for different reasons. Need to
+    // make them consistent
+    failing.forEach((vector: AesEncryptDecryptTestVector) => {
+      const { algorithm, keyLength } = vector;
+      const { name } = algorithm as AesCtrParams;
+      it(`testEncrypt failing ${name} ${keyLength}`, async () => {
+        await assertThrowsAsync(
+          async () => await testEncrypt(vector),
+          'AES-CTR algorithm.length must be between 1 and 128'
+        );
+      });
+      it(`testDecrypt failing ${name} ${keyLength}`, async () => {
+        await assertThrowsAsync(
+          async () => await testDecrypt(vector),
+          'AES-CTR algorithm.length must be between 1 and 128'
+        );
+      });
+    });
+
+    decryptionFailing.forEach((vector: AesEncryptDecryptTestVector) => {
+      const { algorithm, keyLength } = vector;
+      const { name } = algorithm as AesCtrParams;
+      it(`testDecrypt decryptionFailing ${name} ${keyLength}`, async () => {
+        await assertThrowsAsync(
+          async () => await testDecrypt(vector),
+          'error in DoCipher, status: 2'
+        );
+      });
+    });
+  }
+
+  // Test aes-gcm vectors
+  {
+    let { passing, failing, decryptionFailing } = aes_gcm_fixtures;
+
+    passing.forEach((vector: AesEncryptDecryptTestVector) => {
+      const { algorithm, keyLength } = vector;
+      const { name } = algorithm as AesGcmParams;
+      it(`testEncrypt passing ${name} ${keyLength}`, async () => {
+        await testEncrypt(vector);
+      });
+      it(`testEncryptNoEncrypt passing ${name} ${keyLength}`, async () => {
+        await testEncryptNoEncrypt(vector);
+      });
+      it(`testEncryptNoDecrypt passing ${name} ${keyLength}`, async () => {
+        await testEncryptNoDecrypt(vector);
+      });
+      it(`testEncryptWrongAlg passing ${name} ${keyLength}`, async () => {
+        await testEncryptWrongAlg(vector, 'AES-CBC');
+      });
+    });
+
+    failing.forEach((vector: AesEncryptDecryptTestVector) => {
+      const { algorithm, keyLength } = vector;
+      const { name } = algorithm as AesGcmParams;
+      it(`testEncrypt failing ${name} ${keyLength}`, async () => {
+        await assertThrowsAsync(
+          async () => await testEncrypt(vector),
+          'is not a valid AES-GCM tag length'
+        );
+      });
+      it(`testDecrypt failing ${name} ${keyLength}`, async () => {
+        await assertThrowsAsync(
+          async () => await testDecrypt(vector),
+          'is not a valid AES-GCM tag length'
+        );
+      });
+    });
+
+    decryptionFailing.forEach((vector: AesEncryptDecryptTestVector) => {
+      const { algorithm, keyLength } = vector;
+      const { name } = algorithm as AesGcmParams;
+      it(`testDecrypt decryptionFailing ${name} ${keyLength}`, async () => {
+        await assertThrowsAsync(
+          async () => await testDecrypt(vector),
+          'error in DoCipher, status: 2'
+        );
+      });
+    });
+  }
+
+  {
+    const iv = crypto.getRandomValues(new Uint8Array(12));
+    const aad = crypto.getRandomValues(new Uint8Array(32));
+
+    async function testAESGCM2() {
+      const secretKey = (await subtle.generateKey(
+        {
+          name: 'AES-GCM',
+          length: 256,
+        },
+        false,
+        ['encrypt', 'decrypt']
+      )) as CryptoKey;
+
+      const encrypted = await subtle.encrypt(
+        {
+          name: 'AES-GCM',
+          iv,
+          additionalData: aad,
+          tagLength: 128,
+        },
+        secretKey,
+        crypto.getRandomValues(new Uint8Array(32))
+      );
+
+      await subtle.decrypt(
+        {
+          name: 'AES-GCM',
+          iv,
+          additionalData: aad,
+          tagLength: 128,
+        },
+        secretKey,
+        new Uint8Array(encrypted)
+      );
+    }
+
+    it('AES-GCM with iv & additionalData - default AuthTag length', async () => {
+      await testAESGCM2();
+    });
+  }
 });

--- a/example/src/testing/Tests/webcryptoTests/encrypt_decrypt.ts
+++ b/example/src/testing/Tests/webcryptoTests/encrypt_decrypt.ts
@@ -51,7 +51,7 @@ describe('subtle - encrypt / decrypt', () => {
     const buf = crypto.getRandomValues(new Uint8Array(50));
     const counter = crypto.getRandomValues(new Uint8Array(16));
 
-    async function test() {
+    async function testAESCTR() {
       const key = await subtle.generateKey(
         {
           name: 'AES-CTR',
@@ -79,7 +79,7 @@ describe('subtle - encrypt / decrypt', () => {
     }
 
     it('AES-CTR', async () => {
-      await test();
+      await testAESCTR();
     });
   }
 
@@ -88,7 +88,7 @@ describe('subtle - encrypt / decrypt', () => {
     const buf = crypto.getRandomValues(new Uint8Array(50));
     const iv = crypto.getRandomValues(new Uint8Array(16));
 
-    async function test() {
+    async function testAESCBC() {
       const key = await subtle.generateKey(
         {
           name: 'AES-CBC',
@@ -116,7 +116,7 @@ describe('subtle - encrypt / decrypt', () => {
     }
 
     it('AES-CBC', async () => {
-      await test();
+      await testAESCBC();
     });
   }
 
@@ -125,7 +125,7 @@ describe('subtle - encrypt / decrypt', () => {
     const buf = crypto.getRandomValues(new Uint8Array(50));
     const iv = crypto.getRandomValues(new Uint8Array(12));
 
-    async function test() {
+    async function testAESGCM() {
       const key = await subtle.generateKey(
         {
           name: 'AES-GCM',
@@ -153,7 +153,7 @@ describe('subtle - encrypt / decrypt', () => {
     }
 
     it('AES-GCM', async () => {
-      await test();
+      await testAESGCM();
     });
   }
 

--- a/example/src/testing/Tests/webcryptoTests/encrypt_decrypt.ts
+++ b/example/src/testing/Tests/webcryptoTests/encrypt_decrypt.ts
@@ -1,0 +1,163 @@
+import crypto from 'react-native-quick-crypto';
+import { describe, it } from '../../MochaRNAdapter';
+import { expect } from 'chai';
+
+// polyfill encoders
+// @ts-expect-error
+import { polyfillGlobal } from 'react-native/Libraries/Utilities/PolyfillFunctions';
+import RNFE from 'react-native-fast-encoder';
+import type { CryptoKey } from '../../../../../src/keys';
+polyfillGlobal('TextEncoder', () => RNFE);
+
+const { subtle } = crypto;
+
+// This is only a partial test. The WebCrypto Web Platform Tests
+// will provide much greater coverage.
+
+describe('subtle - encrypt / decrypt', () => {
+  // // Test Encrypt/Decrypt RSA-OAEP
+  // {
+  //   const buf = crypto.getRandomValues(new Uint8Array(50));
+
+  //   async function test() {
+  //     const ec = new TextEncoder();
+  //     const { publicKey, privateKey } = await subtle.generateKey({
+  //       name: 'RSA-OAEP',
+  //       modulusLength: 2048,
+  //       publicExponent: new Uint8Array([1, 0, 1]),
+  //       hash: 'SHA-384',
+  //     }, true, ['encrypt', 'decrypt']);
+
+  //     const ciphertext = await subtle.encrypt({
+  //       name: 'RSA-OAEP',
+  //       label: ec.encode('a label')
+  //     }, publicKey, buf);
+
+  //     const plaintext = await subtle.decrypt({
+  //       name: 'RSA-OAEP',
+  //       label: ec.encode('a label')
+  //     }, privateKey, ciphertext);
+
+  //     assert.strictEqual(
+  //       Buffer.from(plaintext).toString('hex'),
+  //       Buffer.from(buf).toString('hex'));
+  //   }
+
+  //   test().then(common.mustCall());
+  // }
+
+  // Test Encrypt/Decrypt AES-CTR
+  {
+    const buf = crypto.getRandomValues(new Uint8Array(50));
+    const counter = crypto.getRandomValues(new Uint8Array(16));
+
+    async function test() {
+      const key = await subtle.generateKey(
+        {
+          name: 'AES-CTR',
+          length: 256,
+        },
+        true,
+        ['encrypt', 'decrypt']
+      );
+
+      const ciphertext = await subtle.encrypt(
+        { name: 'AES-CTR', counter, length: 64 },
+        key as CryptoKey,
+        buf
+      );
+
+      const plaintext = await subtle.decrypt(
+        { name: 'AES-CTR', counter, length: 64 },
+        key as CryptoKey,
+        ciphertext
+      );
+
+      expect(Buffer.from(plaintext).toString('hex')).to.equal(
+        Buffer.from(buf).toString('hex')
+      );
+    }
+
+    it('AES-CTR', async () => {
+      await test();
+    });
+  }
+
+  // Test Encrypt/Decrypt AES-CBC
+  {
+    const buf = crypto.getRandomValues(new Uint8Array(50));
+    const iv = crypto.getRandomValues(new Uint8Array(16));
+
+    async function test() {
+      const key = await subtle.generateKey(
+        {
+          name: 'AES-CBC',
+          length: 256,
+        },
+        true,
+        ['encrypt', 'decrypt']
+      );
+
+      const ciphertext = await subtle.encrypt(
+        { name: 'AES-CBC', iv },
+        key as CryptoKey,
+        buf
+      );
+
+      const plaintext = await subtle.decrypt(
+        { name: 'AES-CBC', iv },
+        key as CryptoKey,
+        ciphertext
+      );
+
+      expect(Buffer.from(plaintext).toString('hex')).to.equal(
+        Buffer.from(buf).toString('hex')
+      );
+    }
+
+    it('AES-CBC', async () => {
+      await test();
+    });
+  }
+
+  // Test Encrypt/Decrypt AES-GCM
+  {
+    const buf = crypto.getRandomValues(new Uint8Array(50));
+    const iv = crypto.getRandomValues(new Uint8Array(12));
+
+    async function test() {
+      const key = await subtle.generateKey(
+        {
+          name: 'AES-GCM',
+          length: 256,
+        },
+        true,
+        ['encrypt', 'decrypt']
+      );
+
+      const ciphertext = await subtle.encrypt(
+        { name: 'AES-GCM', iv },
+        key as CryptoKey,
+        buf
+      );
+
+      const plaintext = await subtle.decrypt(
+        { name: 'AES-GCM', iv },
+        key as CryptoKey,
+        ciphertext
+      );
+
+      expect(Buffer.from(plaintext).toString('hex')).to.equal(
+        Buffer.from(buf).toString('hex')
+      );
+    }
+
+    it('AES-GCM', async () => {
+      await test();
+    });
+  }
+
+  // TODO: when algorithms are fully-implemented, add the tests in
+  //  * test-webcrypto-encrypt-decrypt-aes.js
+  //  * test-webcrypto-encrypt-decrypt-rsa.js
+});

--- a/example/src/testing/Tests/webcryptoTests/sign_verify.ts
+++ b/example/src/testing/Tests/webcryptoTests/sign_verify.ts
@@ -164,4 +164,10 @@ describe('subtle - sign / verify', () => {
 
   //   test('hello world').then(common.mustCall());
   // }
+
+  // TODO: when other algorithms are implemented, add the tests in
+  //  * test-webcrypto-sign-verify-ecdsa.js
+  //  * test-webcrypto-sign-verify-eddsa.js
+  //  * test-webcrypto-sign-verify-hmac.js
+  //  * test-webcrypto-sign-verify-rsa.js
 });

--- a/example/src/testing/Tests/webcryptoTests/sign_verify.ts
+++ b/example/src/testing/Tests/webcryptoTests/sign_verify.ts
@@ -3,12 +3,6 @@ import crypto from 'react-native-quick-crypto';
 import { describe, it } from '../../MochaRNAdapter';
 import { expect } from 'chai';
 
-// polyfill encoders
-// @ts-expect-error
-import { polyfillGlobal } from 'react-native/Libraries/Utilities/PolyfillFunctions';
-import RNFE from 'react-native-fast-encoder';
-polyfillGlobal('TextEncoder', () => RNFE);
-
 const { subtle } = crypto;
 
 describe('subtle - sign / verify', () => {

--- a/example/src/testing/fixtures/aes_cbc.ts
+++ b/example/src/testing/fixtures/aes_cbc.ts
@@ -1,0 +1,153 @@
+import { decodeHex } from '../Tests/util';
+import type {
+  AesEncryptDecryptTestVector,
+  BadPaddingVectorValue,
+  VectorValue,
+} from '../Tests/webcryptoTests/encrypt_decrypt';
+
+const kPlaintext = decodeHex(
+  '546869732073706563696669636174696f6e206465736372696265' +
+    '732061204a6176615363726970742041504920666f722070657266' +
+    '6f726d696e672062617369632063727970746f6772617068696320' +
+    '6f7065726174696f6e7320696e20776562206170706c6963617469' +
+    '6f6e732c20737563682061732068617368696e672c207369676e61' +
+    '747572652067656e65726174696f6e20616e642076657269666963' +
+    '6174696f6e2c20616e6420656e6372797074696f6e20616e642064' +
+    '656372797074696f6e2e204164646974696f6e616c6c792c206974' +
+    '2064657363726962657320616e2041504920666f72206170706c69' +
+    '636174696f6e7320746f2067656e657261746520616e642f6f7220' +
+    '6d616e61676520746865206b6579696e67206d6174657269616c20' +
+    '6e656365737361727920746f20706572666f726d20746865736520' +
+    '6f7065726174696f6e732e205573657320666f7220746869732041' +
+    '50492072616e67652066726f6d2075736572206f72207365727669' +
+    '63652061757468656e7469636174696f6e2c20646f63756d656e74' +
+    '206f7220636f6465207369676e696e672c20616e64207468652063' +
+    '6f6e666964656e7469616c69747920616e6420696e746567726974' +
+    '79206f6620636f6d6d756e69636174696f6e732e'
+);
+
+const kKeyBytes: VectorValue = {
+  '128': decodeHex('dec0d4fcbf3c4741c892dabd1cd4c04e'),
+  '256': decodeHex(
+    '67693823fb1d58073f91ece9cc3af910e5532616a4d27b1' + '3eb7b74d8000bbf30'
+  ),
+};
+
+const iv = decodeHex('55aaf89ba89413d54ea727a76c27a284');
+
+const kCipherText: VectorValue = {
+  '128': decodeHex(
+    '237f03fee70872e78faec148ddbd01bd77cb96e3381ef4ece2afea17a7afd37' +
+      'ccbe461df9c4d58aea6bbbae1b05cfab1e129877cd756c6867c319a3ce05da5' +
+      '0cbef5f1a4f7dce345f269d06cdec1df00e2d927a04e93bf2699e8ceddfe19b' +
+      '9f907b5d76862a3c2a167a1eda70af2255002ffad60146aaa6e5026887f1055' +
+      'f44eac386a0373823aba81ecfffbb270189f52fc01b2845c287d12877440b21' +
+      'fae577272da4e6f00effc4f3f773a764e37f92482e1cd0d4c61d6faaee84367' +
+      'd3b2ce2081bcf364473f9a9fc87d228a2749824b61cbcc6ff44bbab52bcfaf9' +
+      '262cf1b175a90a113ebc75d62ee48869ddccf42a7ec5e390003cafa371aa314' +
+      '85bf43143f96cb57d82c39bcec40506f441a0c0aa35203bf1347bac4b154f40' +
+      '74e29accb1be1e76cce8dddfdccdc8614823671517fc51b65799fdfc173be0c' +
+      '99aee7c45c8e9c3dbd031299cebe3aff9a7342176b5edc9cdce4f14206b82ce' +
+      'ef933f06d8ed0bd0b7546aad9aad842e712af79dd101d8b37675bef6f1d6c5e' +
+      'b38a8649821d45b6c0f996a54f2f5bcbe23f57343cacbfbeb3ab9bcd58ac6f3' +
+      'b28c6fad194b173c8282ba5a74374409ff051fdeb898431dfd6ac35072fb8df' +
+      '783b33217c93dd1b3c10fe187373d64b496188d6d1b16a47fed35e3968aaa82' +
+      '3255dcbc7261c54'
+  ),
+  '256': decodeHex(
+    '29d5798cb5e3c86164853ae36a73193f4d331a39ee8c633f47d38054731aec3' +
+      '46751910e65a1b53a87c138a7d6dc053455deb71b6586569b40947cd4dbfb41' +
+      '2a202c80023280dd16ee38bd531c7a799dd7879780e9c141be5694bf8cc4780' +
+      '8ac64a6fe29f54b3806a6f4b26fea17046b061684bbe61147ac71ee4904b45a' +
+      '674d2533767081eec707de7aad1ee8b2e9ea90620eea704d443e3e9fe665622' +
+      'b02cc459c566880228007ad5a7821683b2dfb5d33f0e83c5ebd865a14b87a1d' +
+      'e155d526749f50456aa8ecc9458c62f02da085e16a2df5d4a0b0801b7299b69' +
+      '091d648c48ab7573df59638529ee032727d7aaca181ea463ff5881e880980dc' +
+      'e59ddec395bd46084728c35d1b07eaa4af66c99573f8b37d427ac21a3ddac6b' +
+      '5988cc730941f0ef1c5034680ef20560fd756f5be5f8d296f00e81c984357c5' +
+      'ff760dfb475416e786bcaf738a25c705eec70263cb4b3ee71596ef5ec9b9db3' +
+      'ad2e497834c94683c4a5206a831fbb603e8add2c91365a6075e0bc2d392e54b' +
+      'f10f32bb24af4ee362e0035fd15d7e70b21d126cf1e84fd22902eed0beab869' +
+      '3bcbfe57a20d1a67681df82d6c359435eda9bb90090ff84d5193b53f2394594' +
+      '6d853da31ed6fe36a903d94d427bc1ccc76d7b31badfe508e6a4abc491e10a6' +
+      'ff86fa4d836e1fd'
+  ),
+};
+
+const kBadPadding: BadPaddingVectorValue = {
+  '128': {
+    zeroPadChar: decodeHex('ee1bf8a9da8aa456cf6624df06a64d0e'),
+    bigPadChar: decodeHex('5b437768fceeaf90114b0ca3d4342e33'),
+    inconsistentPadChars: decodeHex('876570d0036ae21419db4f5e3ad4f2c0'),
+  },
+  '256': {
+    zeroPadChar: decodeHex('01fd8dd61ec1fe448cc89d6ec859b181'),
+    bigPadChar: decodeHex('58076edd4a22616d6319bdde5e5a1b3c'),
+    inconsistentPadChars: decodeHex('98363c943b88c1154d8caa43784a6a3e'),
+  },
+};
+
+const kKeyLengths = ['128', '256'];
+
+const passing: AesEncryptDecryptTestVector[] = [];
+kKeyLengths.forEach((keyLength) => {
+  passing.push({
+    keyBuffer: kKeyBytes[keyLength],
+    algorithm: { name: 'AES-CBC', iv },
+    plaintext: kPlaintext,
+    result: kCipherText[keyLength],
+    keyLength,
+  });
+});
+
+const failing: AesEncryptDecryptTestVector[] = [];
+kKeyLengths.forEach((keyLength) => {
+  failing.push({
+    keyBuffer: kKeyBytes[keyLength],
+    algorithm: {
+      name: 'AES-CBC',
+      iv: iv.slice(0, 8),
+    },
+    plaintext: kPlaintext,
+    result: kCipherText[keyLength],
+    keyLength,
+  });
+
+  const longIv = new Uint8Array(24);
+  longIv.set(iv, 0);
+  longIv.set(iv.slice(0, 8), 16);
+  failing.push({
+    keyBuffer: kKeyBytes[keyLength],
+    algorithm: { name: 'AES-CBC', iv: longIv },
+    plaintext: kPlaintext,
+    result: kCipherText[keyLength],
+    keyLength,
+  });
+});
+
+// Scenarios that should fail decryption because of bad padding
+const decryptionFailing: AesEncryptDecryptTestVector[] = [];
+kKeyLengths.forEach(function (keyLength) {
+  ['zeroPadChar', 'bigPadChar', 'inconsistentPadChars'].forEach(
+    (paddingProblem) => {
+      // @ts-expect-error
+      const badCiphertext = new Uint8Array(kCipherText[keyLength].byteLength);
+      badCiphertext.set(
+        // @ts-expect-error
+        kCipherText[keyLength].slice(0, kCipherText[keyLength].byteLength - 16)
+      );
+      // @ts-expect-error
+      badCiphertext.set(kBadPadding[keyLength][paddingProblem]);
+
+      decryptionFailing.push({
+        keyBuffer: kKeyBytes[keyLength],
+        algorithm: { name: 'AES-CBC', iv },
+        plaintext: kPlaintext,
+        result: badCiphertext,
+        keyLength,
+      });
+    }
+  );
+});
+
+export default { passing, failing, decryptionFailing };

--- a/example/src/testing/fixtures/aes_ctr.ts
+++ b/example/src/testing/fixtures/aes_ctr.ts
@@ -1,0 +1,108 @@
+import { decodeHex } from '../Tests/util';
+import type {
+  AesEncryptDecryptTestVector,
+  VectorValue,
+} from '../Tests/webcryptoTests/encrypt_decrypt';
+
+const kPlaintext = decodeHex(
+  '546869732073706563696669636174696f6e206465736372696265' +
+    '732061204a6176615363726970742041504920666f722070657266' +
+    '6f726d696e672062617369632063727970746f6772617068696320' +
+    '6f7065726174696f6e7320696e20776562206170706c6963617469' +
+    '6f6e732c20737563682061732068617368696e672c207369676e61' +
+    '747572652067656e65726174696f6e20616e642076657269666963' +
+    '6174696f6e2c20616e6420656e6372797074696f6e20616e642064' +
+    '656372797074696f6e2e204164646974696f6e616c6c792c206974' +
+    '2064657363726962657320616e2041504920666f72206170706c69' +
+    '636174696f6e7320746f2067656e657261746520616e642f6f7220' +
+    '6d616e61676520746865206b6579696e67206d6174657269616c20' +
+    '6e656365737361727920746f20706572666f726d20746865736520' +
+    '6f7065726174696f6e732e205573657320666f7220746869732041' +
+    '50492072616e67652066726f6d2075736572206f72207365727669' +
+    '63652061757468656e7469636174696f6e2c20646f63756d656e74' +
+    '206f7220636f6465207369676e696e672c20616e64207468652063' +
+    '6f6e666964656e7469616c69747920616e6420696e746567726974' +
+    '79206f6620636f6d6d756e69636174696f6e732e'
+);
+
+const kKeyBytes: VectorValue = {
+  '128': decodeHex('dec0d4fcbf3c4741c892dabd1cd4c04e'),
+  '256': decodeHex(
+    '67693823fb1d58073f91ece9cc3af910e5532616a4d27b1' + '3eb7b74d8000bbf30'
+  ),
+};
+
+const counter = decodeHex('55aaf89ba89413d54ea727a76c27a284');
+
+const kCiphertext: VectorValue = {
+  '128': decodeHex(
+    'e91175fda4f5ea57c52b0d000bbe98af68c0a59058aeed8ab5b7063503a1ce4' +
+      '70d79dad174f90aaafaa5449d848dc8b2c557d1e7fa4b9a41a2fb1e9fea1414' +
+      'b593dab40c04f14b4f81400fe43c93990181b096a15561169aea177f100416e' +
+      '20b6810b00ee1b04fef67f3bede28baf4d41d397daf1511e9020d7766e9e604' +
+      '10de38e1432dbffa0f992dc1f0d4756544e8c765af7df706f90e009db9384c3' +
+      '3e44dea543c2a77bbd52022de41e7d71a498de7feb9760eb47e503366c88dcc' +
+      '2d1a387788de2d8f78e72c2bdd8815bc8a54e8d0eee275683ca5041290f031a' +
+      'd5a4454efa17cc4907718f3ef4b75fedbd13583254f441a15a8a3323b12f40b' +
+      '8fbebc816cf9b468d8d7a5a0fb548498c39a6ed84615f894929838aef8e3016' +
+      '60f76b632493f23709fedfd5e107f78267f331b60a38c146f9710484a4acdef' +
+      'f110b3b7745ff83aa8cb5de9e15b11e20a785572041f2852a1981156edcf07e' +
+      '46eb64144449cce74b9cc94163a6fda8ae19219721d60b757b5b5ec718dabd5' +
+      '0954b6e6a393f656f6346f40229d0c50e01c15701f2a4fe5d25a174edf9b90e' +
+      'e0c0ebf9e06b5fe00558638a1ea3781403b0c9206d9e814d6a79fb7a56060e1' +
+      'c7176af36c6a1ad635981a9bfd8007d8cf6d9f93f0e8e22b93a9a2ccd7090ab' +
+      '1df63cea3f040'
+  ),
+  '256': decodeHex(
+    '37529a432f50ba4e53385f8266ec3deccceceade7ae29395e9291076c95bb9a' +
+      '24f4792fcdd6ea5894b815edb5d5e4022fabe055a06b1a7e01979555b579838' +
+      '64bf23019cb1b37ffdadb057f728cfb2af0a33d146344cfba0accb4dbf613a7' +
+      'bee523ca6d6860e474a9c0f4d068d4c0acd94cc55cbf21e4285ca15116c9702' +
+      '0f2c33b4585008f8fe97c9e29c0627c5d47c48d94be88b9b16c7f2df740a8d2' +
+      'a07556305b82b919f7a87ca2ed19db27262c277c213f2a7eca25e5a6adbea43' +
+      '0ba2e1061198171054285aff9e0869c638dcd524cbf1f255da675acad6d7867' +
+      '9a9958b7a8f9bb21dd9c580ad196f9a0e4c6a6500d7bb21df74cd5934ce3c4d' +
+      '8d1f39d34a2adb58d224c48097887cde9d3be146a3ea3bade4c6864cf9e445b' +
+      '5c4c2b3ef4e2b8f5eea0ab1c0b9abe7a4fe5b2c0b1d94df6b12953d3273260e' +
+      '80bd094dec97a3177a9cec0b5042be1804040c9439403b8f72f7426fa756ad6' +
+      '266cf2c8659e740329dd0d24f9f85497662cad739f71d6174011c77f8f31fb4' +
+      '4226288dfb86817ef17116321c71bb9ed97db6e990f62058580f006683431f2' +
+      '29662f1d5e3cdaffe0335467ca72635688c939ec8b32d6465f651a635f73c0a' +
+      '4e7f0aadb0e81f5bcbfaec2671ac97fdc2fd32f24c941775c37a6810d4b171b' +
+      'c8aba90a86603'
+  ),
+};
+
+const kKeyLengths = ['128', '256'];
+
+const passing: AesEncryptDecryptTestVector[] = [];
+kKeyLengths.forEach((keyLength) => {
+  passing.push({
+    keyBuffer: kKeyBytes[keyLength],
+    algorithm: { name: 'AES-CTR', counter, length: 64 },
+    plaintext: kPlaintext,
+    result: kCiphertext[keyLength],
+    keyLength,
+  });
+});
+
+const failing: AesEncryptDecryptTestVector[] = [];
+kKeyLengths.forEach((keyLength) => {
+  failing.push({
+    keyBuffer: kKeyBytes[keyLength],
+    algorithm: { name: 'AES-CTR', counter, length: 0 },
+    plaintext: kPlaintext,
+    result: kCiphertext[keyLength],
+    keyLength,
+  });
+
+  failing.push({
+    keyBuffer: kKeyBytes[keyLength],
+    algorithm: { name: 'AES-CTR', counter, length: 129 },
+    plaintext: kPlaintext,
+    result: kCiphertext[keyLength],
+    keyLength,
+  });
+});
+
+export default { passing, failing, decryptionFailing: [] };

--- a/example/src/testing/fixtures/aes_gcm.ts
+++ b/example/src/testing/fixtures/aes_gcm.ts
@@ -109,6 +109,7 @@ kKeyLengths.forEach((keyLength) => {
       algorithm: { name: 'AES-GCM', iv, additionalData, tagLength },
       plaintext: kPlaintext,
       result,
+      keyLength,
     });
 
     const noadresult = new Uint8Array(cipherText.byteLength + byteCount);

--- a/example/src/testing/fixtures/aes_gcm.ts
+++ b/example/src/testing/fixtures/aes_gcm.ts
@@ -1,0 +1,149 @@
+import type { TagLength } from '../../../../src/keys';
+import { decodeHex } from '../Tests/util';
+import type {
+  AesEncryptDecryptTestVector,
+  VectorValue,
+} from '../Tests/webcryptoTests/encrypt_decrypt';
+
+const kPlaintext = decodeHex(
+  '546869732073706563696669636174696f6e206465736372696265' +
+    '732061204a6176615363726970742041504920666f722070657266' +
+    '6f726d696e672062617369632063727970746f6772617068696320' +
+    '6f7065726174696f6e7320696e20776562206170706c6963617469' +
+    '6f6e732c20737563682061732068617368696e672c207369676e61' +
+    '747572652067656e65726174696f6e20616e642076657269666963' +
+    '6174696f6e2c20616e6420656e6372797074696f6e20616e642064' +
+    '656372797074696f6e2e204164646974696f6e616c6c792c206974' +
+    '2064657363726962657320616e2041504920666f72206170706c69' +
+    '636174696f6e7320746f2067656e657261746520616e642f6f7220' +
+    '6d616e61676520746865206b6579696e67206d6174657269616c20' +
+    '6e656365737361727920746f20706572666f726d20746865736520' +
+    '6f7065726174696f6e732e205573657320666f7220746869732041' +
+    '50492072616e67652066726f6d2075736572206f72207365727669' +
+    '63652061757468656e7469636174696f6e2c20646f63756d656e74' +
+    '206f7220636f6465207369676e696e672c20616e64207468652063' +
+    '6f6e666964656e7469616c69747920616e6420696e746567726974' +
+    '79206f6620636f6d6d756e69636174696f6e732e'
+);
+
+const kKeyBytes: VectorValue = {
+  '128': decodeHex('dec0d4fcbf3c4741c892dabd1cd4c04e'),
+  '256': decodeHex(
+    '67693823fb1d58073f91ece9cc3af910e5532616a4d27b1' + '3eb7b74d8000bbf30'
+  ),
+};
+
+const iv = decodeHex(
+  '3a92732aa6ea39bf3986e0c73fa920002' + '02175385ef8adeac2c87335eb928dd4'
+);
+
+const additionalData = decodeHex(
+  '5468657265206172652037206675727468657220656469746f72696' +
+    '16c206e6f74657320696e2074686520646f63756d656e742e'
+);
+
+const tag: VectorValue = {
+  '128': decodeHex('c2e2c6fdef1cc5f07bd8b097efc8b8b7'),
+  '256': decodeHex('bceff1309f15d500f12a554cc21c313c'),
+};
+
+const tag_with_empty_ad: VectorValue = {
+  '128': decodeHex('de330b1724defaf81b621e519623dcc6'),
+  '256': decodeHex('f4ba56cb9a25bff8f6398b82e02fd9ee'),
+};
+
+// AES-GCM produces ciphertext and a tag.
+const kCiphertext: VectorValue = {
+  '128': decodeHex(
+    'b4f128b7693493eee0afafeca8f4f17909cae1ed38d8fdfeba666fcfe4be82b19ff6' +
+      '0635f971e4fe517efdbf642bfb936b5ba6e7c9f1b4d6702f7ba4ba86364116b5c952' +
+      'ec3b348bac2729597b3e66a75296fa5d60a98759f5ffa4c0a99f19108b914c049083' +
+      '94c5cc2e176ec1e47f78f21836f0b5a262f4f944867a7e97266c7444966d26c2159f' +
+      '8ccdb7236197ba789116eb16d2dfbb8fa2b75dc468336035eafab84ced9d25cbe257' +
+      'de4bf05fdade4051a54bc9d8be0d74d945422fa144f74afd9db5a27935205b7ce669' +
+      'e011bb323d4d674f4739a374ea951b69181f9f0380822a5e7dc88efb94c91195e854' +
+      '321112cbbae2a4e3ca4c4110a3e084341f658148ab9f2ab1fd6256c95f753e0ccd4e' +
+      '247ec47959b925a142b575ba477c846e781bf6a3120d5ac87f52d1f1aa49f78960f4' +
+      'fefb77479c1b6b35212d16009030200b74157df6d9ab9ee08eea8df2a8599a42e3a1' +
+      'b66001584e0c07ef1ece1f596f6b2a25f194e80108fb7592b70930275e3b46e61aa5' +
+      '619c8c8d1f3e0ace3730cf00c5cac56c85af5004109adfff04c4bcb2f01d0d7805e1' +
+      'ca0323e19e5c9849cd6b9de0f563c2ab9cf5f7b7a5283ec86e1d97ce64af5824f25a' +
+      '045249fa8cf5d9099923f2ce4ec579730f508065bff05b97f93e3ef412031187ded2' +
+      '5d957b'
+  ),
+  '256': decodeHex(
+    '0861eb7146208783d2d17ca0ffb6091d7dc11bf0812e0289a98e3d079136aacf9f6f' +
+      '275f573fa21b0612dbd774225a3972f4669143063398f7a5f27464dbb148b1116e43' +
+      '5ddb64d914cf599a2d25695343a28ceb8128b1caae3694379cc1e8f986a3c3337274' +
+      '4126496360f9e0451177babcb52b4e9c4c8ae23f05f8095e1a0102eb27ae4a2fb716' +
+      '282f2f0d64770c43b2b838a7ee8f0d2cd0b9976c0611347ab6d2cf2adb254a5e7e24' +
+      'f9252004da2cee4538db1f4dad2ebb672470d5fc2857a4f0a39f20817db26c2f1c1f' +
+      '242a73240e91c39cbf2ea3f9b51f5a491e4839df3f3c4f8c0e751f91de9c79ed2091' +
+      '8f600cfe2315153ba8ab9ad9003bcaaf67d6c0af1a122b36b0de4b16077afde0913d' +
+      '2ad049ed548dd1d5e42ef43b0944062358bd0a3e09551c2c521399a0b2f038a0f4c9' +
+      'ad4d3d14e31eb4a71069b9c15fcf2917864ec6b65d1859f7e74be9c289f272c2be82' +
+      '8aee5e89c1c27389becfa9539b0ed2a081c3a1eaddff7243620c5d2941b7f467f765' +
+      '52f67d577d4e15ba66cd142820c9ae0f34f0d9b4a26c06d3291287e8b812bca99dbe' +
+      '4ca64bb07f27fb16cb995031f17c89977bcc2b9fbeb1c41275a92e98fb2d19a41b91' +
+      'd6e4370f0283d850ffccaf643b910f6728212dffc8feac8a143a57b6c094db2958e6' +
+      'e546f9'
+  ),
+};
+
+const kKeyLengths = ['128', '256'];
+const kTagLengths: TagLength[] = [32, 64, 96, 104, 112, 120, 128];
+
+const passing: AesEncryptDecryptTestVector[] = [];
+kKeyLengths.forEach((keyLength) => {
+  const cipherText = kCiphertext[keyLength] as Uint8Array;
+  kTagLengths.forEach((tagLength) => {
+    const byteCount = tagLength / 8;
+    const result = new Uint8Array(cipherText.byteLength + byteCount);
+    result.set(cipherText, 0);
+    result.set(
+      (tag[keyLength] as Uint8Array).slice(0, byteCount),
+      cipherText.byteLength
+    );
+    passing.push({
+      keyBuffer: kKeyBytes[keyLength],
+      algorithm: { name: 'AES-GCM', iv, additionalData, tagLength },
+      plaintext: kPlaintext,
+      result,
+    });
+
+    const noadresult = new Uint8Array(cipherText.byteLength + byteCount);
+    noadresult.set(cipherText, 0);
+    noadresult.set(
+      (tag_with_empty_ad[keyLength] as Uint8Array).slice(0, byteCount),
+      cipherText.byteLength
+    );
+    passing.push({
+      keyBuffer: kKeyBytes[keyLength],
+      algorithm: { name: 'AES-GCM', iv, tagLength },
+      plaintext: kPlaintext,
+      result: noadresult,
+      keyLength,
+    });
+  });
+});
+
+const failing: AesEncryptDecryptTestVector[] = [];
+kKeyLengths.forEach((keyLength) => {
+  [24, 48, 72, 95, 129].forEach((badTagLength) => {
+    failing.push({
+      keyBuffer: kKeyBytes[keyLength],
+      algorithm: {
+        name: 'AES-GCM',
+        iv,
+        additionalData,
+        // @ts-expect-error
+        tagLength: badTagLength,
+      },
+      plaintext: kPlaintext,
+      result: kCiphertext[keyLength],
+      keyLength,
+    });
+  });
+});
+
+export default { passing, failing, decryptionFailing: [] };

--- a/implementation-coverage.md
+++ b/implementation-coverage.md
@@ -206,11 +206,11 @@ This document attempts to describe the implementation status of Crypto APIs/Inte
 # `SubtleCrypto`
 
 * 🚧 Class: `SubtleCrypto`
-  * ❌ `subtle.decrypt(algorithm, key, data)`
+  * 🚧 `subtle.decrypt(algorithm, key, data)`
   * 🚧 `subtle.deriveBits(algorithm, baseKey, length)`
   * ❌ `subtle.deriveKey(algorithm, baseKey, derivedKeyAlgorithm, extractable, keyUsages)`
   * ✅ `subtle.digest(algorithm, data)`
-  * ❌ `subtle.encrypt(algorithm, key, data)`
+  * 🚧 `subtle.encrypt(algorithm, key, data)`
   * 🚧 `subtle.exportKey(format, key)`
   * 🚧 `subtle.generateKey(algorithm, extractable, keyUsages)`
   * 🚧 `subtle.importKey(format, keyData, algorithm, extractable, keyUsages)`
@@ -223,9 +223,9 @@ This document attempts to describe the implementation status of Crypto APIs/Inte
 | Algorithm  | Status |
 | ---------  | :----: |
 | `RSA-OAEP` |  |
-| `AES-CTR`  |  |
-| `AES-CBC`  |  |
-| `AES-GCM`  |  |
+| `AES-CTR`  | ✅ |
+| `AES-CBC`  | ✅ |
+| `AES-GCM`  | ✅ |
 
 ## `subtle.deriveBits`
 | Algorithm  | Status |
@@ -257,9 +257,9 @@ This document attempts to describe the implementation status of Crypto APIs/Inte
 | Algorithm  | Status |
 | ---------  | :----: |
 | `RSA-OAEP` |  |
-| `AES-CTR`  |  |
-| `AES-CBC`  |  |
-| `AES-GCM`  |  |
+| `AES-CTR`  | ✅ |
+| `AES-CBC`  | ✅ |
+| `AES-GCM`  | ✅ |
 
 ## `subtle.exportKey`
 | Key Type            | `spki` | `pkcs8` | `jwk` | `raw` |

--- a/implementation-coverage.md
+++ b/implementation-coverage.md
@@ -108,7 +108,7 @@ This document attempts to describe the implementation status of Crypto APIs/Inte
   * ✅ `crypto.createVerify(algorithm[, options])`
   * ❌ `crypto.diffieHellman(options)`
   * ❌ `crypto.hash(algorithm, data[, outputEncoding])`
-  * ❌ `crypto.generateKey(type, options, callback)`
+  * 🚧 `crypto.generateKey(type, options, callback)`
   * 🚧 `crypto.generateKeyPair(type, options, callback)`
   * 🚧 `crypto.generateKeyPairSync(type, options)`
   * ❌ `crypto.generateKeySync(type, options)`
@@ -150,7 +150,7 @@ This document attempts to describe the implementation status of Crypto APIs/Inte
 ## `crypto.generateKey`
 | type       | Status |
 | ---------  | :----: |
-| `aes`      | ❌ |
+| `aes`      | ✅ |
 | `hmac`     | ❌ |
 
 ## `crypto.generateKeyPair`
@@ -182,7 +182,7 @@ This document attempts to describe the implementation status of Crypto APIs/Inte
 ## `crypto.generateKeySync`
 | type       | Status |
 | ---------  | :----: |
-| `aes`      | ❌ |
+| `aes`      | ✅ |
 | `hmac`     | ❌ |
 
 
@@ -302,10 +302,10 @@ This document attempts to describe the implementation status of Crypto APIs/Inte
 | Algorithm  | Status |
 | ---------  | :----: |
 | `HMAC`     |  |
-| `AES-CTR`  |  |
-| `AES-CBC`  |  |
-| `AES-GCM`  |  |
-| `AES-KW`   |  |
+| `AES-CTR`  | ✅ |
+| `AES-CBC`  | ✅ |
+| `AES-GCM`  | ✅ |
+| `AES-KW`   | ✅ |
 
 ## `subtle.importKey`
 | Key Type            | `spki` | `pkcs8` | `jwk` | `raw` |

--- a/src/NativeQuickCrypto/aes.ts
+++ b/src/NativeQuickCrypto/aes.ts
@@ -7,7 +7,8 @@ export type AESCipher = (
   handle: KeyObjectHandle,
   data: ArrayBuffer,
   variant: AESKeyVariant,
-  param1?: any,
-  param2?: any,
-  param3?: any
+  iv_or_counter?: ArrayBuffer,
+  length?: number,
+  authTag?: ArrayBuffer,
+  additionalData?: ArrayBuffer
 ) => Promise<ArrayBuffer>;

--- a/src/NativeQuickCrypto/aes.ts
+++ b/src/NativeQuickCrypto/aes.ts
@@ -1,0 +1,13 @@
+import type { AESKeyVariant } from '../aes';
+import type { CipherOrWrapMode } from '../keys';
+import type { KeyObjectHandle } from './webcrypto';
+
+export type AESCipher = (
+  mode: CipherOrWrapMode,
+  handle: KeyObjectHandle,
+  data: ArrayBuffer,
+  variant: AESKeyVariant,
+  param1?: any,
+  param2?: any,
+  param3?: any
+) => Promise<ArrayBuffer>;

--- a/src/NativeQuickCrypto/keygen.ts
+++ b/src/NativeQuickCrypto/keygen.ts
@@ -1,0 +1,11 @@
+import type { AesKeyGenParams, SecretKeyObject, SecretKeyType } from '../keys';
+
+export type GenerateSecretKeyMethod = (
+  type: SecretKeyType,
+  options: AesKeyGenParams // | HmacKeyGenParams,
+) => Promise<SecretKeyObject>;
+
+export type GenerateSecretKeySyncMethod = (
+  type: SecretKeyType,
+  options: AesKeyGenParams // | HmacKeyGenParams,
+) => SecretKeyObject;

--- a/src/NativeQuickCrypto/keygen.ts
+++ b/src/NativeQuickCrypto/keygen.ts
@@ -1,11 +1,7 @@
-import type { AesKeyGenParams, SecretKeyObject, SecretKeyType } from '../keys';
+import type { KeyObjectHandle } from './webcrypto';
 
 export type GenerateSecretKeyMethod = (
-  type: SecretKeyType,
-  options: AesKeyGenParams // | HmacKeyGenParams,
-) => Promise<SecretKeyObject>;
+  length: number
+) => Promise<KeyObjectHandle>;
 
-export type GenerateSecretKeySyncMethod = (
-  type: SecretKeyType,
-  options: AesKeyGenParams // | HmacKeyGenParams,
-) => SecretKeyObject;
+export type GenerateSecretKeySyncMethod = (length: number) => KeyObjectHandle;

--- a/src/NativeQuickCrypto/webcrypto.ts
+++ b/src/NativeQuickCrypto/webcrypto.ts
@@ -9,6 +9,10 @@ import type {
   NamedCurve,
 } from '../keys';
 import type { SignVerify } from './sig';
+import type {
+  GenerateSecretKeyMethod,
+  GenerateSecretKeySyncMethod,
+} from './keygen';
 
 type KeyDetail = {
   length?: number;
@@ -46,5 +50,7 @@ export type webcrypto = {
   aesCipher: AESCipher;
   createKeyObjectHandle: CreateKeyObjectHandle;
   ecExportKey: ECExportKey;
+  generateSecretKey: GenerateSecretKeyMethod;
+  generateSecretKeySync: GenerateSecretKeySyncMethod;
   signVerify: SignVerify;
 };

--- a/src/NativeQuickCrypto/webcrypto.ts
+++ b/src/NativeQuickCrypto/webcrypto.ts
@@ -1,3 +1,4 @@
+import type { AESCipher } from './aes';
 import type {
   AsymmetricKeyType,
   JWK,
@@ -42,7 +43,8 @@ export type KeyObjectHandle = {
 type CreateKeyObjectHandle = () => KeyObjectHandle;
 
 export type webcrypto = {
-  ecExportKey: ECExportKey;
+  aesCipher: AESCipher;
   createKeyObjectHandle: CreateKeyObjectHandle;
+  ecExportKey: ECExportKey;
   signVerify: SignVerify;
 };

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -209,8 +209,8 @@ export function validateString(str: any, name?: string): str is string {
   return isString;
 }
 
-export function validateFunction(f: any): f is Function {
-  return f != null && typeof f === 'function';
+export function validateFunction(f: any): boolean {
+  return f !== null && typeof f === 'function';
 }
 
 export function isStringOrBuffer(val: any): val is string | ArrayBuffer {

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -13,11 +13,6 @@ import type {
 } from './keys';
 import { type CipherKey } from 'crypto'; // @types/node
 
-export enum Fn {
-  kAsync,
-  kSync,
-}
-
 export type BufferLike = ArrayBuffer | Buffer | ArrayBufferView;
 export type BinaryLike = string | ArrayBuffer | Buffer | TypedArray;
 export type BinaryLikeNode = CipherKey | BinaryLike;

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -3,6 +3,7 @@ import type {
   AnyAlgorithm,
   DeriveBitsAlgorithm,
   EncryptDecryptAlgorithm,
+  EncryptDecryptParams,
   HashAlgorithm,
   KeyPairAlgorithm,
   KeyUsage,
@@ -491,9 +492,9 @@ export const validateMaxBufferLength = (
 // adapted for Node.js from Deno's implementation
 // https://github.com/denoland/deno/blob/v1.29.1/ext/crypto/00_crypto.js#L195
 export const normalizeAlgorithm = (
-  algorithm: SubtleAlgorithm | AnyAlgorithm,
+  algorithm: SubtleAlgorithm | EncryptDecryptParams | AnyAlgorithm,
   op: Operation
-): SubtleAlgorithm => {
+): SubtleAlgorithm | EncryptDecryptParams => {
   if (typeof algorithm === 'string')
     return normalizeAlgorithm({ name: algorithm }, op);
 

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -13,6 +13,11 @@ import type {
 } from './keys';
 import { type CipherKey } from 'crypto'; // @types/node
 
+export enum Fn {
+  kAsync,
+  kSync,
+}
+
 export type BufferLike = ArrayBuffer | Buffer | ArrayBufferView;
 export type BinaryLike = string | ArrayBuffer | Buffer | TypedArray;
 export type BinaryLikeNode = CipherKey | BinaryLike;

--- a/src/aes.ts
+++ b/src/aes.ts
@@ -26,6 +26,7 @@ import {
   type TagLength,
   type AESLength,
   type AesKeyGenParams,
+  SecretKeyType,
 } from './keys';
 import { generateKey } from './keygen';
 
@@ -293,13 +294,15 @@ export const aesGenerateKey = async (
     );
   }
 
-  const key = await generateKeyAsync('aes', { length }).catch((err: Error) => {
-    throw lazyDOMException(
-      'The operation failed for an operation-specific reason' +
-        `[${err.message}]`,
-      { name: 'OperationError', cause: err }
-    );
-  });
+  const key = await generateKeyAsync(SecretKeyType.AES, { length }).catch(
+    (err: Error) => {
+      throw lazyDOMException(
+        'The operation failed for an operation-specific reason' +
+          `[${err.message}]`,
+        { name: 'OperationError', cause: err }
+      );
+    }
+  );
 
   return new CryptoKey(
     key as SecretKeyObject,

--- a/src/aes.ts
+++ b/src/aes.ts
@@ -26,7 +26,7 @@ import {
   type AESLength,
   type AesKeyGenParams,
 } from './keys';
-import { generateKeySync } from './keygen';
+import { generateKeyPromise } from './keygen';
 
 // needs to match the values in cpp/webcrypto/crypto_aes.{h,cpp}
 export enum AESKeyVariant {
@@ -290,16 +290,16 @@ export const aesGenerateKey = async (
     );
   }
 
-  // TODO: after development, switch back to async here
-
-  // const key = await generateKey('aes', { length }).catch((err: Error) => {
-  //   throw lazyDOMException(
-  //     'The operation failed for an operation-specific reason' +
-  //       `[${err.message}]`,
-  //     { name: 'OperationError', cause: err }
-  //   );
-  // });
-  const key = generateKeySync('aes', { length });
+  const [err, key] = await generateKeyPromise('aes', { length });
+  if (err) {
+    throw lazyDOMException(
+      `aesGenerateKey (generateKeyPromise) failed: [${err.message}]`,
+      {
+        name: 'OperationError',
+        cause: err,
+      }
+    );
+  }
 
   return new CryptoKey(
     key as SecretKeyObject,

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import {
   generateKeyPair,
   generateKeyPairSync,
 } from './Cipher';
+import { generateKey, generateKeySync } from './keygen';
 import { createSign, createVerify } from './sig';
 import { createHmac } from './Hmac';
 import { createHash } from './Hash';
@@ -34,8 +35,10 @@ const QuickCrypto = {
   publicEncrypt,
   publicDecrypt,
   privateDecrypt,
+  generateKey,
   generateKeyPair,
   generateKeyPairSync,
+  generateKeySync,
   createSign,
   createVerify,
   subtle,

--- a/src/keygen.ts
+++ b/src/keygen.ts
@@ -1,10 +1,6 @@
 import { NativeQuickCrypto } from './NativeQuickCrypto/NativeQuickCrypto';
 import { validateFunction } from './Utils';
-import {
-  SecretKeyObject,
-  type AesKeyGenParams,
-  type SecretKeyType,
-} from './keys';
+import { SecretKeyObject, SecretKeyType, type AesKeyGenParams } from './keys';
 
 export type KeyGenCallback = (err: Error | null, key?: SecretKeyObject) => void;
 

--- a/src/keygen.ts
+++ b/src/keygen.ts
@@ -1,6 +1,11 @@
 import { NativeQuickCrypto } from './NativeQuickCrypto/NativeQuickCrypto';
-import { validateFunction } from './Utils';
-import { SecretKeyObject, SecretKeyType, type AesKeyGenParams } from './keys';
+import { lazyDOMException, validateFunction } from './Utils';
+import { kAesKeyLengths } from './aes';
+import {
+  SecretKeyObject,
+  type SecretKeyType,
+  type AesKeyGenParams,
+} from './keys';
 
 export type KeyGenCallback = (err: Error | null, key?: SecretKeyObject) => void;
 
@@ -9,13 +14,44 @@ export const generateKey = async (
   options: AesKeyGenParams, // | HmacKeyGenParams,
   callback: KeyGenCallback
 ): Promise<SecretKeyObject> => {
+  validateLength(type, options.length);
   validateFunction(callback);
-  return await NativeQuickCrypto.webcrypto.generateSecretKey(type, options);
+  const handle = await NativeQuickCrypto.webcrypto.generateSecretKey(
+    options.length
+  );
+  return new SecretKeyObject(handle);
 };
 
 export const generateKeySync = (
   type: SecretKeyType,
   options: AesKeyGenParams // | HmacKeyGenParams,
 ): SecretKeyObject => {
-  return NativeQuickCrypto.webcrypto.generateSecretKeySync(type, options);
+  validateLength(type, options.length);
+  const handle = NativeQuickCrypto.webcrypto.generateSecretKeySync(
+    options.length
+  );
+  return new SecretKeyObject(handle);
+};
+
+const validateLength = (type: SecretKeyType, length: number) => {
+  switch (type) {
+    case 'aes':
+      if (!kAesKeyLengths.includes(length)) {
+        throw lazyDOMException(
+          'AES key length must be 128, 192, or 256 bits',
+          'OperationError'
+        );
+      }
+      break;
+    case 'hmac':
+      if (length < 8 || length > 2 ** 31 - 1) {
+        throw lazyDOMException(
+          'HMAC key length must be between 8 and 2^31 - 1',
+          'OperationError'
+        );
+      }
+      break;
+    default:
+      throw new Error(`Unsupported key type '${type}' for generateKey()`);
+  }
 };

--- a/src/keygen.ts
+++ b/src/keygen.ts
@@ -1,0 +1,25 @@
+import { NativeQuickCrypto } from './NativeQuickCrypto/NativeQuickCrypto';
+import { validateFunction } from './Utils';
+import {
+  SecretKeyObject,
+  type AesKeyGenParams,
+  type SecretKeyType,
+} from './keys';
+
+export type KeyGenCallback = (err: Error | null, key?: SecretKeyObject) => void;
+
+export const generateKey = async (
+  type: SecretKeyType,
+  options: AesKeyGenParams, // | HmacKeyGenParams,
+  callback: KeyGenCallback
+): Promise<SecretKeyObject> => {
+  validateFunction(callback);
+  return await NativeQuickCrypto.webcrypto.generateSecretKey(type, options);
+};
+
+export const generateKeySync = (
+  type: SecretKeyType,
+  options: AesKeyGenParams // | HmacKeyGenParams,
+): SecretKeyObject => {
+  return NativeQuickCrypto.webcrypto.generateSecretKeySync(type, options);
+};

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -44,6 +44,7 @@ export type KeyPairAlgorithm =
   | CFRGKeyPairAlgorithm;
 
 export type SecretKeyAlgorithm = 'HMAC' | AESAlgorithm;
+export type SecretKeyType = 'hmac' | 'aes';
 
 export type SignVerifyAlgorithm =
   | 'RSASSA-PKCS1-v1_5'
@@ -79,13 +80,18 @@ export type AesCtrParams = {
 export type AesGcmParams = {
   name: 'AES-GCM';
   iv: BufferLike;
-  tagLength: TagLength;
-  additionalData: BufferLike;
+  tagLength?: TagLength;
+  additionalData?: BufferLike;
 };
 
 export type AesKwParams = {
   name: 'AES-KW';
   wrappingKey?: BufferLike;
+};
+
+export type AesKeyGenParams = {
+  length: AESLength;
+  name?: AESAlgorithm;
 };
 
 export type TagLength = 32 | 64 | 96 | 104 | 112 | 120 | 128;

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -44,11 +44,7 @@ export type KeyPairAlgorithm =
   | CFRGKeyPairAlgorithm;
 
 export type SecretKeyAlgorithm = 'HMAC' | AESAlgorithm;
-export type SecretKeyTypeIn = 'hmac' | 'aes';
-export enum SecretKeyType {
-  AES,
-  HMAC,
-}
+export type SecretKeyType = 'hmac' | 'aes';
 
 export type SignVerifyAlgorithm =
   | 'RSASSA-PKCS1-v1_5'

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -79,8 +79,8 @@ export type AesCtrParams = {
 export type AesGcmParams = {
   name: 'AES-GCM';
   iv: BufferLike;
-  additionalData?: BufferLike;
-  tagLength?: TagLength;
+  tagLength: TagLength;
+  additionalData: BufferLike;
 };
 
 export type AesKwParams = {

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -2,6 +2,8 @@ import {
   type BinaryLike,
   binaryLikeToArrayBuffer,
   isStringOrBuffer,
+  type BufferLike,
+  type TypedArray,
 } from './Utils';
 import type { KeyObjectHandle } from './NativeQuickCrypto/webcrypto';
 import { NativeQuickCrypto } from './NativeQuickCrypto/NativeQuickCrypto';
@@ -34,18 +36,14 @@ export type KeyPairType = 'rsa' | 'rsa-pss' | 'ec';
 export type RSAKeyPairAlgorithm = 'RSASSA-PKCS1-v1_5' | 'RSA-PSS' | 'RSA-OAEP';
 export type ECKeyPairAlgorithm = 'ECDSA' | 'ECDH';
 export type CFRGKeyPairAlgorithm = 'Ed25519' | 'Ed448' | 'X25519' | 'X448';
+export type AESAlgorithm = 'AES-CTR' | 'AES-CBC' | 'AES-GCM' | 'AES-KW';
 
 export type KeyPairAlgorithm =
   | RSAKeyPairAlgorithm
   | ECKeyPairAlgorithm
   | CFRGKeyPairAlgorithm;
 
-export type SecretKeyAlgorithm =
-  | 'HMAC'
-  | 'AES-CTR'
-  | 'AES-CBC'
-  | 'AES-GCM'
-  | 'AES-KW';
+export type SecretKeyAlgorithm = 'HMAC' | AESAlgorithm;
 
 export type SignVerifyAlgorithm =
   | 'RSASSA-PKCS1-v1_5'
@@ -61,6 +59,44 @@ export type DeriveBitsAlgorithm =
   | 'ECDH'
   | 'X25519'
   | 'X448';
+
+export type RsaOaepParams = {
+  name: 'RSA-OAEP';
+  label?: BufferLike;
+};
+
+export type AesCbcParams = {
+  name: 'AES-CBC';
+  iv: BufferLike;
+};
+
+export type AesCtrParams = {
+  name: 'AES-CTR';
+  counter: TypedArray;
+  length: number;
+};
+
+export type AesGcmParams = {
+  name: 'AES-GCM';
+  iv: BufferLike;
+  additionalData?: BufferLike;
+  tagLength?: TagLength;
+};
+
+export type AesKwParams = {
+  name: 'AES-KW';
+  wrappingKey?: BufferLike;
+};
+
+export type TagLength = 32 | 64 | 96 | 104 | 112 | 120 | 128;
+
+export type AESLength = 128 | 192 | 256;
+
+export type EncryptDecryptParams =
+  | AesCbcParams
+  | AesCtrParams
+  | AesGcmParams
+  | RsaOaepParams;
 
 export type EncryptDecryptAlgorithm =
   | 'RSA-OAEP'
@@ -180,6 +216,13 @@ export type CryptoKeyPair = {
   publicKey: KeyPairKey;
   privateKey: KeyPairKey;
 };
+
+export enum CipherOrWrapMode {
+  kWebCryptoCipherEncrypt,
+  kWebCryptoCipherDecrypt,
+  // kWebCryptoWrapKey,
+  // kWebCryptoUnwrapKey,
+}
 
 function option(name: string, objName: string | undefined) {
   return objName === undefined

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -44,7 +44,11 @@ export type KeyPairAlgorithm =
   | CFRGKeyPairAlgorithm;
 
 export type SecretKeyAlgorithm = 'HMAC' | AESAlgorithm;
-export type SecretKeyType = 'hmac' | 'aes';
+export type SecretKeyTypeIn = 'hmac' | 'aes';
+export enum SecretKeyType {
+  AES,
+  HMAC,
+}
 
 export type SignVerifyAlgorithm =
   | 'RSASSA-PKCS1-v1_5'

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -621,7 +621,7 @@ export class SecretKeyObject extends KeyObject {
   //   return this[kHandle].getSymmetricKeySize();
   // }
 
-  export(options: EncodingOptions) {
+  export(options?: EncodingOptions) {
     if (options !== undefined) {
       if (options.format === 'jwk') {
         throw new Error('SecretKey export for jwk is not implemented');

--- a/src/subtle.ts
+++ b/src/subtle.ts
@@ -309,7 +309,7 @@ const cipherOrWrap = async (
   // key must have the proper usage.
   if (
     key.algorithm.name !== algorithm.name ||
-    key.usages.includes(op as KeyUsage)
+    !key.usages.includes(op as KeyUsage)
   ) {
     throw lazyDOMException(
       'The requested operation is not valid for the provided key',

--- a/src/subtle.ts
+++ b/src/subtle.ts
@@ -10,6 +10,7 @@ import {
   type CryptoKeyPair,
   CipherOrWrapMode,
   type EncryptDecryptParams,
+  type AesKeyGenParams,
 } from './keys';
 import {
   hasAnyNotIn,
@@ -26,7 +27,12 @@ import {
 import { ecImportKey, ecExportKey, ecGenerateKey, ecdsaSignVerify } from './ec';
 import { pbkdf2DeriveBits } from './pbkdf2';
 import { asyncDigest } from './Hash';
-import { aesCipher, aesImportKey, getAlgorithmName } from './aes';
+import {
+  aesCipher,
+  aesGenerateKey,
+  aesImportKey,
+  getAlgorithmName,
+} from './aes';
 import { rsaImportKey } from './rsa';
 
 const exportKeySpki = async (key: CryptoKey): Promise<ArrayBuffer | any> => {
@@ -561,16 +567,19 @@ class Subtle {
       //   resultType = 'CryptoKey';
       //   result = await hmacGenerateKey(algorithm, extractable, keyUsages);
       //   break;
-      // case 'AES-CTR':
-      // // Fall through
-      // case 'AES-CBC':
-      // // Fall through
-      // case 'AES-GCM':
-      // // Fall through
-      // case 'AES-KW':
-      //   resultType = 'CryptoKey';
-      //   result = await aesGenerateKey(algorithm, extractable, keyUsages);
-      //   break;
+      case 'AES-CTR':
+      // Fall through
+      case 'AES-CBC':
+      // Fall through
+      case 'AES-GCM':
+      // Fall through
+      case 'AES-KW':
+        result = await aesGenerateKey(
+          algorithm as AesKeyGenParams,
+          extractable,
+          keyUsages
+        );
+        break;
       default:
         throw new Error(
           `'subtle.generateKey()' is not implemented for ${algorithm.name}.

--- a/src/subtle.ts
+++ b/src/subtle.ts
@@ -564,7 +564,6 @@ class Subtle {
         checkCryptoKeyPairUsages(result);
         break;
       // case 'HMAC':
-      //   resultType = 'CryptoKey';
       //   result = await hmacGenerateKey(algorithm, extractable, keyUsages);
       //   break;
       case 'AES-CTR':

--- a/src/subtle.ts
+++ b/src/subtle.ts
@@ -338,11 +338,18 @@ const cipherOrWrap = async (
 
 class Subtle {
   async decrypt(
-    _algorithm: EncryptDecryptParams,
-    _key: CryptoKey,
-    _data: BufferLike
+    algorithm: EncryptDecryptParams,
+    key: CryptoKey,
+    data: BufferLike
   ): Promise<ArrayBuffer> {
-    throw new Error('subtle.decrypt() is not implemented');
+    const normalizedAlgorithm = normalizeAlgorithm(algorithm, 'decrypt');
+    return cipherOrWrap(
+      CipherOrWrapMode.kWebCryptoCipherDecrypt,
+      normalizedAlgorithm as EncryptDecryptParams,
+      key,
+      bufferLikeToArrayBuffer(data),
+      'decrypt'
+    );
   }
 
   async digest(


### PR DESCRIPTION
Add `aes` support for the following functions:
* `subtle.encrypt()`
* `subtle.decrypt()`
* `subtle.generateKey()`
* `crypto.generateKey()`
* `crypto.generateKeySync()`

fixes #283 
fixes #285 