### PR TITLE
chore: run GHA on `0.x` branch too

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - 0.x
     paths:
       - '.github/workflows/build-android.yml'
       - 'android/**'

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - 0.x
     paths:
       - '.github/workflows/build-ios.yml'
       - 'ios/**'

--- a/.github/workflows/validate-android.yml
+++ b/.github/workflows/validate-android.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - 0.x
     paths:
       - '.github/workflows/validate-android.yml'
       - 'android/**'

--- a/.github/workflows/validate-cpp.yml
+++ b/.github/workflows/validate-cpp.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - 0.x
     paths:
       - '.github/workflows/validate-cpp.yml'
       - 'cpp/**'

--- a/.github/workflows/validate-js.yml
+++ b/.github/workflows/validate-js.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - 0.x
     paths:
       - '.github/workflows/validate-js.yml'
       - 'src/**'

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -15,7 +15,13 @@ import type {
 import { type CipherKey } from 'crypto'; // @types/node
 
 export type BufferLike = ArrayBuffer | Buffer | SBuffer | ArrayBufferView;
-export type BinaryLike = string | ArrayBuffer | Buffer | SBuffer | TypedArray | DataView;
+export type BinaryLike =
+  | string
+  | ArrayBuffer
+  | Buffer
+  | SBuffer
+  | TypedArray
+  | DataView;
 export type BinaryLikeNode = CipherKey | BinaryLike;
 
 export type BinaryToTextEncoding = 'base64' | 'base64url' | 'hex' | 'binary';


### PR DESCRIPTION
Separating the `0.x` and `main` branches for Nitro Modules / new architecture means that we need to run GHA on both of them going forward.  The workflows were configured to only run on `main`.