### PR TITLE
fix: return `Buffer` from `getAuthTag`

### DIFF
--- a/example/src/testing/tests/CipherTests/CipherivDecipheriv.ts
+++ b/example/src/testing/tests/CipherTests/CipherivDecipheriv.ts
@@ -79,7 +79,7 @@ describe('createCipheriv/createDecipheriv', () => {
       defaultCipher.update(plaintext, 'utf8', 'hex');
       defaultCipher.final('hex');
       const defaultAuthTag = defaultCipher.getAuthTag();
-      assert.strictEqual(Buffer.from(defaultAuthTag).length, 16);
+      assert.strictEqual(defaultAuthTag.length, 16);
     });
 
     it('AES-GCM with key and iv ', () => {
@@ -91,14 +91,14 @@ describe('createCipheriv/createDecipheriv', () => {
       let encrypted = cipher.update(plaintext, 'utf8', 'hex');
       encrypted += cipher.final('hex');
       const authTag = cipher.getAuthTag();
-      assert.strictEqual(Buffer.from(authTag).length, 4);
+      assert.strictEqual(authTag.length, 4);
 
       // Decryption
       const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv, {
         // using an uncommon auth tag length for corner case checking. default is usually 16.
         authTagLength: 4,
       });
-      decipher.setAuthTag(Buffer.from(authTag));
+      decipher.setAuthTag(authTag);
       let decrypted = decipher.update(encrypted, 'hex', 'utf8');
       decrypted += decipher.final('utf8');
 

--- a/src/Cipher.ts
+++ b/src/Cipher.ts
@@ -222,8 +222,8 @@ class CipherCommon extends Stream.Transform {
     return this;
   }
 
-  public getAuthTag(): ArrayBuffer {
-    return this.internal.getAuthTag();
+  public getAuthTag(): Buffer {
+    return Buffer.from(this.internal.getAuthTag());
   }
 
   public setAuthTag(tag: Buffer): this {


### PR DESCRIPTION
This fixes `getAuthTag` returning an `ArrayBuffer` (unexpected) instead of a `Buffer` (expected).

Node `crypto` has been returning `Buffer` since at least Node 16:
- https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/v16/crypto.d.ts#L927
- https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/v18/crypto.d.ts#L956
- https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/v20/crypto.d.ts#L960
- https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/crypto.d.ts#L918

Note: I wasn't sure whether to do this on the 0.x branch or main. Let me know if you want me to update the target branch.