### PR TITLE
fix: when algo is an object of SubtleAlgorithm

### DIFF
--- a/src/Hashnames.ts
+++ b/src/Hashnames.ts
@@ -1,4 +1,4 @@
-import type { HashAlgorithm } from './keys';
+import type { HashAlgorithm, SubtleAlgorithm } from './keys';
 
 export enum HashContext {
   Node,
@@ -79,10 +79,13 @@ const kHashNames: HashNames = {
 }
 
 export function normalizeHashName(
-  algo: string | HashAlgorithm | undefined,
+  algo: string | HashAlgorithm | SubtleAlgorithm | undefined,
   context: HashContext = HashContext.Node,
 ): HashAlgorithm {
   if (typeof algo !== 'undefined') {
+    if(typeof algo === 'object') {
+      algo = algo.name;
+    }
     const normAlgo = algo.toString().toLowerCase();
     try {
       const alias = kHashNames[normAlgo]![context] as HashAlgorithm;

--- a/src/Hashnames.ts
+++ b/src/Hashnames.ts
@@ -83,7 +83,7 @@ export function normalizeHashName(
   context: HashContext = HashContext.Node,
 ): HashAlgorithm {
   if (typeof algo !== 'undefined') {
-    if(typeof algo === 'object') {
+    if (typeof algo === 'object') {
       algo = algo.name;
     }
     const normAlgo = algo.toString().toLowerCase();

--- a/test/hashnames.test.ts
+++ b/test/hashnames.test.ts
@@ -5,6 +5,7 @@ test('normalizeHashName happy', () => {
   expect(normalizeHashName('SHA-256')).toBe('sha256');
   expect(normalizeHashName('SHA-384')).toBe('sha384');
   expect(normalizeHashName('SHA-512')).toBe('sha512');
+  expect(normalizeHashName({name:'SHA-256'})).toBe('sha256');
 });
 
 test('normalizeHashName sad', () => {

--- a/test/hashnames.test.ts
+++ b/test/hashnames.test.ts
@@ -5,7 +5,7 @@ test('normalizeHashName happy', () => {
   expect(normalizeHashName('SHA-256')).toBe('sha256');
   expect(normalizeHashName('SHA-384')).toBe('sha384');
   expect(normalizeHashName('SHA-512')).toBe('sha512');
-  expect(normalizeHashName({name:'SHA-256'})).toBe('sha256');
+  expect(normalizeHashName({ name: 'SHA-256' })).toBe('sha256');
 });
 
 test('normalizeHashName sad', () => {


### PR DESCRIPTION
When we call Crypto.subtle.verify, we need to pass verifyAlgorithm like this:

```javascript
    const verifyAlgorithm = {
        name: 'ECDSA',
        hash: { name: 'SHA-256' },
    };
    return crypto.subtle.verify(verifyAlgorithm, key, signature, data);
```

In this case, `algo.toString().toLowercase()` will not work.

This PR resolves the problem.