### PR TITLE
fix: Retrieval of bridge on iOS when reloading the app

### DIFF
--- a/ios/QuickCryptoModule.mm
+++ b/ios/QuickCryptoModule.mm
@@ -9,12 +9,17 @@
 
 @implementation QuickCryptoModule
 
+@synthesize bridge=_bridge;
+
 RCT_EXPORT_MODULE(QuickCrypto)
+
+- (void)setBridge:(RCTBridge *)bridge {
+  _bridge = bridge;
+}
 
 RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(install) {
   NSLog(@"Installing JSI bindings for react-native-quick-crypto...");
-  RCTBridge* bridge = [RCTBridge currentBridge];
-  RCTCxxBridge* cxxBridge = (RCTCxxBridge*)bridge;
+  RCTCxxBridge* cxxBridge = (RCTCxxBridge*)_bridge;
   if (cxxBridge == nil) {
     return @false;
   }
@@ -26,7 +31,7 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(install) {
     return @false;
   }
   auto& runtime = *jsiRuntime;
-  auto callInvoker = bridge.jsCallInvoker;
+  auto callInvoker = _bridge.jsCallInvoker;
 
   auto workerQueue =
       std::make_shared<margelo::DispatchQueue::dispatch_queue>("margelo crypto thread");


### PR DESCRIPTION
Fixes https://github.com/margelo/react-native-quick-crypto/issues/462 by applying https://github.com/mrousavy/react-native-mmkv/pull/602

I am on RN 0.74 with Expo SDK 51, and on iOS as soon as I reload the iOS app (e.g. pressing `r` on the device or Expo CLI) the app throws the error

> Failed to install react-native-quick-crypto, the native initializer function does not exist. Are you trying to use QuickCrypto from different JS Runtimes?
