### PR TITLE
fix: excluded libreactnative.so (#506)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -134,6 +134,7 @@ android {
             "**/libreact_nativemodule_core.so",
             "**/libturbomodulejsijni.so",
             "**/MANIFEST.MF",
+            "**/libreactnative.so",
     ]
   }
 


### PR DESCRIPTION
Had this issue while using this package in a project created with react-native 0.76.
I've tested this fix myself and everything is working fine in my project.