### PR TITLE
fix: stop a crash in HostObject dtor

### DIFF
--- a/cpp/JSIUtils/MGLTypedArray.cpp
+++ b/cpp/JSIUtils/MGLTypedArray.cpp
@@ -50,7 +50,13 @@ class PropNameIDCache {
   const jsi::PropNameID &getConstructorNameProp(jsi::Runtime &runtime,
                                                 MGLTypedArrayKind kind);
 
-  void invalidate() { props.erase(props.begin(), props.end()); }
+  void invalidate() {
+    /** This call (and attempts to use props.clear()) crash 💥 when the
+     *  JSI runtime has already been destroyed.  So we are commenting it out
+     *  and waiting for Nitro and 1.0 to fix this the proper way.
+     */
+    //props.erase(props.begin(), props.end());
+  }
 
  private:
   std::unordered_map<Prop, std::unique_ptr<jsi::PropNameID>> props;

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -323,7 +323,7 @@ PODS:
   - react-native-quick-base64 (2.1.2):
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
-  - react-native-quick-crypto (0.7.7):
+  - react-native-quick-crypto (0.7.6):
     - OpenSSL-Universal
     - RCT-Folly (= 2021.07.22.00)
     - React
@@ -628,7 +628,7 @@ SPEC CHECKSUMS:
   React-logger: 8edc785c47c8686c7962199a307015e2ce9a0e4f
   react-native-fast-encoder: 6f59e9b08e2bc5a8bf1f36e1630cdcfd66dd18af
   react-native-quick-base64: 61228d753294ae643294a75fece8e0e80b7558a6
-  react-native-quick-crypto: cb37232c60e48158ab55b4f48aacf46ddce963c0
+  react-native-quick-crypto: 03d888b32a7d58adfe93926ee226c1adc5519c6e
   react-native-safe-area-context: ab8f4a3d8180913bd78ae75dd599c94cce3d5e9a
   React-NativeModulesApple: b6868ee904013a7923128892ee4a032498a1024a
   React-perflogger: 31ea61077185eb1428baf60c0db6e2886f141a5a

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -323,7 +323,7 @@ PODS:
   - react-native-quick-base64 (2.1.2):
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
-  - react-native-quick-crypto (0.7.6):
+  - react-native-quick-crypto (0.7.7):
     - OpenSSL-Universal
     - RCT-Folly (= 2021.07.22.00)
     - React
@@ -628,7 +628,7 @@ SPEC CHECKSUMS:
   React-logger: 8edc785c47c8686c7962199a307015e2ce9a0e4f
   react-native-fast-encoder: 6f59e9b08e2bc5a8bf1f36e1630cdcfd66dd18af
   react-native-quick-base64: 61228d753294ae643294a75fece8e0e80b7558a6
-  react-native-quick-crypto: 03d888b32a7d58adfe93926ee226c1adc5519c6e
+  react-native-quick-crypto: cb37232c60e48158ab55b4f48aacf46ddce963c0
   react-native-safe-area-context: ab8f4a3d8180913bd78ae75dd599c94cce3d5e9a
   React-NativeModulesApple: b6868ee904013a7923128892ee4a032498a1024a
   React-perflogger: 31ea61077185eb1428baf60c0db6e2886f141a5a


### PR DESCRIPTION
This is "fine" for now, will be fixed properly by using Nitro in `1.x` and higher.