### PR TITLE
fix: move host object variable outside functions to hold ref

### DIFF
--- a/src/pbkdf2.ts
+++ b/src/pbkdf2.ts
@@ -29,6 +29,8 @@ function sanitizeInput(input: BinaryLike, errorMsg: string): ArrayBuffer {
   }
 }
 
+const nativePbkdf2 = NativeQuickCrypto.pbkdf2;
+
 export function pbkdf2(
   password: Password,
   salt: Salt,
@@ -44,7 +46,6 @@ export function pbkdf2(
   const sanitizedSalt = sanitizeInput(salt, WRONG_SALT);
   const normalizedDigest = normalizeHashName(digest, HashContext.Node);
 
-  const nativePbkdf2 = NativeQuickCrypto.pbkdf2;
   nativePbkdf2
     .pbkdf2(
       sanitizedPassword,
@@ -74,7 +75,6 @@ export function pbkdf2Sync(
   const sanitizedSalt = sanitizeInput(salt, WRONG_SALT);
   const algo = digest ? normalizeHashName(digest, HashContext.Node) : 'sha1';
 
-  const nativePbkdf2 = NativeQuickCrypto.pbkdf2;
   const result: ArrayBuffer = nativePbkdf2.pbkdf2Sync(
     sanitizedPassword,
     sanitizedSalt,


### PR DESCRIPTION
In #419, I moved the host object variable inside the `pbkdf2()` and `pbkdf2Sync()` functions.  This does not allow JS to hold onto the reference and if things are GC'd it causes crashes on the native side.

This PR reverts the change.

Probable fix for #544 