### PR TITLE
fix: assembleAndroidTest building

### DIFF
--- a/packages/react-native-quick-crypto/android/build.gradle
+++ b/packages/react-native-quick-crypto/android/build.gradle
@@ -127,6 +127,8 @@ android {
   packagingOptions {
     doNotStrip resolveBuildType() == 'debug' ? "**/**/*.so" : ''
     excludes = [
+            "META-INF",
+            "META-INF/**",
             "**/libc++_shared.so",
             "**/libfbjni.so",
             "**/libreactnativejni.so",


### PR DESCRIPTION
When trying to implement UI tests for Android I got the following error:
```
Execution failed for task ':react-native-quick-crypto:mergeDebugAndroidTestJavaResource'.
> A failure occurred while executing com.android.build.gradle.internal.tasks.MergeJavaResWorkAction
   > 2 files found with path 'META-INF/com.android.tools/proguard/coroutines.pro' from inputs:
      - ~/.gradle/caches/8.8/transforms/63fe3045b8abd462b74b6e64f9d86a35/transformed/jetified-kotlinx-coroutines-core-jvm-1.6.1.jar
      - ~/.gradle/caches/8.8/transforms/dc8560c5b960aeb173e49bf1b90f8764/transformed/jetified-kotlinx-coroutines-android-1.6.1.jar
```
The new unreleased version 1.0.0 [already contains this fix](https://github.com/margelo/react-native-quick-crypto/blob/main/packages/react-native-quick-crypto/android/build.gradle#L81-L82), so I want to add this fix for version 0.7.12 until the new version comes out.