### PR TITLE
Fix inconsistent return type of pbkdf2

### DIFF
--- a/packages/react-native-quick-crypto/src/pbkdf2.ts
+++ b/packages/react-native-quick-crypto/src/pbkdf2.ts
@@ -70,7 +70,7 @@ export function pbkdf2Sync(
   iterations: number,
   keylen: number,
   digest?: string,
-): ArrayBuffer {
+): Buffer {
   const sanitizedPassword = sanitizeInput(password, WRONG_PASS);
   const sanitizedSalt = sanitizeInput(salt, WRONG_SALT);
   const algo = digest ? normalizeHashName(digest, HashContext.Node) : 'sha1';
@@ -83,7 +83,7 @@ export function pbkdf2Sync(
     algo,
   );
 
-  return result;
+  return Buffer.from(result);
 }
 
 // We need this because the typescript  overload signatures in pbkdf2() above do


### PR DESCRIPTION
Hi,

I found a regression in 0.x.
`pbkdf2Sync` has been returning `Buffer`, but v0.7.13 returns `Uint8Array`.
`pbkdf2` still returns `Buffer`.

This commit broke the behavior: https://github.com/margelo/react-native-quick-crypto/commit/889498318ac96ee1f243b2be39e33f4be92cf32c
But I couldn't find any reason for this change.

On the main branch, the return type of `pbkdf2Sync` is `Buffer`, so I think this is a mistake.
https://github.com/margelo/react-native-quick-crypto/blob/83d2aed323b2182c10c5943d29fb84e9a0b5405b/packages/react-native-quick-crypto/src/pbkdf2.ts#L77

@boorad Can you check it?