### PR TITLE
fix: include correct endian header for Mac Catalyst builds

### DIFF
--- a/packages/react-native-quick-crypto/deps/fastpbkdf2/fastpbkdf2.c
+++ b/packages/react-native-quick-crypto/deps/fastpbkdf2/fastpbkdf2.c
@@ -17,7 +17,11 @@
 #include <assert.h>
 #include <string.h>
 #if defined(__GNUC__)
-#include <endian.h>
+  #if TARGET_OS_MACCATALYST
+    #include <machine/endian.h>  // Mac Catalyst
+  #else  
+    #include <endian.h>          // iOS
+  #endif
 #endif
 
 #include <openssl/sha.h>


### PR DESCRIPTION
This change updates the platform check to correctly include <machine/endian.h> when building for Mac Catalyst.