### PR TITLE
fix: Imports to use TARGET_OS_MACCATALYST

### DIFF
--- a/packages/react-native-quick-crypto/deps/fastpbkdf2/fastpbkdf2.c
+++ b/packages/react-native-quick-crypto/deps/fastpbkdf2/fastpbkdf2.c
@@ -16,6 +16,7 @@
 
 #include <assert.h>
 #include <string.h>
+#include <TargetConditionals.h>  // <-- Required for TARGET_OS_* macros
 #if defined(__GNUC__)
   #if TARGET_OS_MACCATALYST
     #include <machine/endian.h>  // Mac Catalyst


### PR DESCRIPTION
Added the import to use TARGET_OS_MACCATALYST to fix the endian header import issue in catalyst.