### PR TITLE
feat: updates sodium and openssl version for 16 KB page size support

### DIFF
--- a/packages/react-native-quick-crypto/android/build.gradle
+++ b/packages/react-native-quick-crypto/android/build.gradle
@@ -53,7 +53,7 @@ android {
     externalNativeBuild {
       cmake {
         cppFlags "-frtti -fexceptions -Wall -fstack-protector-all"
-        arguments "-DANDROID_STL=c++_shared", 
+        arguments "-DANDROID_STL=c++_shared",
                   "-DSODIUM_ENABLED=${sodiumEnabled}",
                   "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
         abiFilters (*reactNativeArchitectures())
@@ -143,11 +143,11 @@ dependencies {
   implementation project(":react-native-nitro-modules")
 
   // Add a dependency on OpenSSL
-  implementation 'io.github.ronickg:openssl:3.3.2'
+  implementation 'io.github.ronickg:openssl:3.3.2-1'
 
   if (sodiumEnabled) {
     // Add a dependency on libsodium
-    implementation 'io.github.ronickg:sodium:1.0.20'
+    implementation 'io.github.ronickg:sodium:1.0.20-1'
   }
 }
 


### PR DESCRIPTION
I've rebuilt the maven libs for both sodium and openssl with 16 KB page size enabled.

closes #759