### PR TITLE
fix(ci): use Node 22 in release workflow to avoid npm 11 workspace bug

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,9 @@ jobs:
       - name: Setup Node.js (for npm publish with OIDC)
         uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          # Node 24 / npm 11 has a bug with workspace:* protocol
+          # https://github.com/npm/cli/issues/4367
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Setup Ruby (for CocoaPods)


### PR DESCRIPTION
## Summary

Fixes the Release CI failure caused by npm 11 (bundled with Node 24) choking on the `workspace:*` protocol.

## Problem

```
npm error Cannot read properties of null (reading 'matches')
```

This is a [known npm bug](https://github.com/npm/cli/issues/4367) where npm's arborist module fails to parse `workspace:*` dependency specifiers properly.

## Solution

Downgrade from Node 24 to Node 22 in the release workflow. Node 22 uses npm 10.x which doesn't have this bug.

## Testing

Run the Release workflow with dry-run enabled to verify it completes successfully.