### PR TITLE
fix: add --workspaces-update=false to npm version for npm 11 compatibility

### DIFF
--- a/packages/react-native-quick-crypto/package.json
+++ b/packages/react-native-quick-crypto/package.json
@@ -111,7 +111,10 @@
   "release-it": {
     "npm": {
       "publish": true,
-      "skipChecks": true
+      "skipChecks": true,
+      "versionArgs": [
+        "--workspaces-update=false"
+      ]
     },
     "git": false,
     "github": {


### PR DESCRIPTION
## Summary

Fixes the Release CI workflow failing with `npm error Cannot read properties of null (reading 'matches')` during `npm version` step.

## Problem

After upgrading to Bun 1.3, the lockfile format changed to `configVersion: 1` which records workspace dependencies as `workspace:*` symlinks. npm 11's arborist has issues walking this node_modules structure, causing `npm version` to fail.

## Solution

Add `--workspaces-update=false` to the `npm.versionArgs` in release-it config. This prevents npm from walking the workspace tree during version bump. The `@release-it/bumper` plugin already handles updating `example/package.json` explicitly.

## Changes

- Add `versionArgs: ["--workspaces-update=false"]` to release-it npm config

## Testing

Merge and run Release workflow with dry-run enabled to verify `npm version` succeeds.