### PR TITLE
fix(ios): define BLAKE3_NO_* macros for x86_64 simulator

### DIFF
--- a/packages/react-native-quick-crypto/QuickCrypto.podspec
+++ b/packages/react-native-quick-crypto/QuickCrypto.podspec
@@ -168,7 +168,11 @@ Pod::Spec.new do |s|
     "CLANG_CXX_LANGUAGE_STANDARD" => "c++20",
     "CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES" => "YES",
     # Exclude ARM NEON source when building x86_64 simulator (no NEON support).
-    "EXCLUDED_SOURCE_FILE_NAMES[sdk=iphonesimulator*][arch=x86_64]" => "deps/blake3/c/blake3_neon.c"
+    "EXCLUDED_SOURCE_FILE_NAMES[sdk=iphonesimulator*][arch=x86_64]" => "deps/blake3/c/blake3_neon.c",
+    # Disable x86 SIMD intrinsics on iOS simulator — the .c implementation files are already
+    # excluded above, but blake3_dispatch.c still references the symbols unless these macros
+    # are defined. Mirrors the Android CMakeLists.txt approach (line 18-22).
+    "GCC_PREPROCESSOR_DEFINITIONS[sdk=iphonesimulator*][arch=x86_64]" => "$(inherited) BLAKE3_NO_AVX512 BLAKE3_NO_AVX2 BLAKE3_NO_SSE41 BLAKE3_NO_SSE2"
   }
 
   # Add cpp subdirectories to header search paths


### PR DESCRIPTION
## Summary

Companion to #884. That PR excluded `blake3_neon.c` for x86_64 simulator (compile-time fix), but x86 SIMD symbols (AVX-512, AVX2, SSE4.1, SSE2) still cause **linker errors**:

```
Undefined symbols for architecture x86_64:
  _blake3_compress_in_place_avx512
  _blake3_compress_in_place_sse2
  _blake3_compress_in_place_sse41
  _blake3_compress_xof_avx512
  ...
```

The `.c` implementation files (`blake3_avx512.c`, etc.) are correctly excluded via `exclude_files`, but `blake3_dispatch.c` still references those symbols — it forward-declares and calls them unless `BLAKE3_NO_*` macros are defined:

```c
#if !defined(BLAKE3_NO_AVX512)
  if (features & AVX512VL) {
    blake3_compress_in_place_avx512(cv, block, block_len, counter, flags);
    return;
  }
#endif
```

Android's `CMakeLists.txt` already handles this (lines 18-22) with `-DBLAKE3_NO_AVX512 -DBLAKE3_NO_AVX2 ...`, but the iOS podspec doesn't.

This PR adds conditional `GCC_PREPROCESSOR_DEFINITIONS` scoped to `[sdk=iphonesimulator*][arch=x86_64]`, mirroring the Android approach. Blake3 falls back to its portable C implementation (the SIMD paths were never reachable on the simulator anyway).

- Device builds (ARM64): **unaffected** — scoped to simulator SDK only
- ARM64 simulator: **unaffected** — scoped to x86_64 arch only

## Related

- Fixes #918
- Companion to #884

## Testing

- Applied this fix as a `pnpm patch` on v1.0.9, ran EAS Build with `development-simulator` profile (x86_64 iOS Simulator) — build now succeeds where it previously failed with undefined symbols