### PR TITLE
test: add regression tests for issue #118 (error queue pollution)

### DIFF
--- a/example/src/hooks/useTestsList.ts
+++ b/example/src/hooks/useTestsList.ts
@@ -23,6 +23,7 @@ import '../tests/keys/generate_key';
 import '../tests/keys/generate_keypair';
 import '../tests/keys/keyobject_from_tocryptokey_tests';
 import '../tests/keys/public_cipher';
+import '../tests/keys/sign_verify_error_queue';
 import '../tests/keys/sign_verify_oneshot';
 import '../tests/keys/sign_verify_streaming';
 import '../tests/pbkdf2/pbkdf2_tests';

--- a/example/src/tests/keys/sign_verify_error_queue.ts
+++ b/example/src/tests/keys/sign_verify_error_queue.ts
@@ -1,0 +1,121 @@
+/**
+ * Regression test for GitHub issue #118:
+ * "Failed to read private key" after calling other crypto operations.
+ *
+ * The original bug was caused by OpenSSL error queue pollution — calling
+ * operations like pbkdf2Sync before sign() would leave stale errors in the
+ * per-thread error queue, causing subsequent key parsing to fail.
+ */
+
+import {
+  Buffer,
+  sign,
+  verify,
+  createHash,
+  createHmac,
+  pbkdf2Sync,
+  randomBytes,
+  createCipheriv,
+  createDecipheriv,
+  generateKeyPairSync,
+} from 'react-native-quick-crypto';
+import { expect } from 'chai';
+import { test } from '../util';
+import { rsaPrivateKeyPem, rsaPublicKeyPem } from './fixtures';
+
+const SUITE = 'keys.sign/verify';
+
+const testData = Buffer.from('test data for issue 118');
+
+const ITERATIONS = 10;
+
+test(SUITE, 'sign after pbkdf2Sync (repeated)', () => {
+  for (let i = 0; i < ITERATIONS; i++) {
+    pbkdf2Sync('password', 'salt', 1000, 32, 'SHA-256');
+    const sig = sign('SHA256', testData, rsaPrivateKeyPem);
+    const valid = verify('SHA256', testData, rsaPublicKeyPem, sig);
+    expect(valid).to.equal(true, `iteration ${i} failed`);
+  }
+});
+
+test(SUITE, 'sign after createHash (repeated)', () => {
+  for (let i = 0; i < ITERATIONS; i++) {
+    createHash('sha256').update('some data').digest();
+    const sig = sign('SHA256', testData, rsaPrivateKeyPem);
+    const valid = verify('SHA256', testData, rsaPublicKeyPem, sig);
+    expect(valid).to.equal(true, `iteration ${i} failed`);
+  }
+});
+
+test(SUITE, 'sign after createHmac (repeated)', () => {
+  for (let i = 0; i < ITERATIONS; i++) {
+    createHmac('sha256', 'secret').update('some data').digest();
+    const sig = sign('SHA256', testData, rsaPrivateKeyPem);
+    const valid = verify('SHA256', testData, rsaPublicKeyPem, sig);
+    expect(valid).to.equal(true, `iteration ${i} failed`);
+  }
+});
+
+test(SUITE, 'sign after AES cipher/decipher (repeated)', () => {
+  const key = Buffer.alloc(32, 0xab);
+  const iv = Buffer.alloc(16, 0xcd);
+  const plaintext = Buffer.from('hello world');
+
+  for (let i = 0; i < ITERATIONS; i++) {
+    const cipher = createCipheriv('aes-256-cbc', key, iv);
+    const encrypted = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+
+    const decipher = createDecipheriv('aes-256-cbc', key, iv);
+    Buffer.concat([decipher.update(encrypted), decipher.final()]);
+
+    const sig = sign('SHA256', testData, rsaPrivateKeyPem);
+    const valid = verify('SHA256', testData, rsaPublicKeyPem, sig);
+    expect(valid).to.equal(true, `iteration ${i} failed`);
+  }
+});
+
+test(SUITE, 'sign after mixed crypto operations (repeated)', () => {
+  for (let i = 0; i < ITERATIONS; i++) {
+    pbkdf2Sync('password', 'salt', 100, 32, 'SHA-512');
+    createHash('sha512').update(randomBytes(64)).digest();
+    createHmac('sha384', 'key').update('data').digest();
+    pbkdf2Sync('pass2', 'salt2', 100, 64, 'SHA-384');
+
+    const sig = sign('SHA256', testData, rsaPrivateKeyPem);
+    const valid = verify('SHA256', testData, rsaPublicKeyPem, sig);
+    expect(valid).to.equal(true, `iteration ${i} failed`);
+  }
+});
+
+test(SUITE, 'Ed25519 sign after mixed crypto operations', () => {
+  const { privateKey, publicKey } = generateKeyPairSync('ed25519', {
+    publicKeyEncoding: { type: 'spki', format: 'pem' },
+    privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+  });
+
+  for (let i = 0; i < ITERATIONS; i++) {
+    pbkdf2Sync('password', 'salt', 100, 32, 'SHA-256');
+    createHash('sha256').update('noise').digest();
+
+    const sig = sign(null, testData, privateKey as string);
+    const valid = verify(null, testData, publicKey as string, sig);
+    expect(valid).to.equal(true, `iteration ${i} failed`);
+  }
+});
+
+test(SUITE, 'ECDSA sign after mixed crypto operations', () => {
+  const { privateKey, publicKey } = generateKeyPairSync('ec', {
+    namedCurve: 'P-256',
+    publicKeyEncoding: { type: 'spki', format: 'pem' },
+    privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+  });
+
+  for (let i = 0; i < ITERATIONS; i++) {
+    pbkdf2Sync('password', 'salt', 100, 32, 'SHA-256');
+    createHash('sha384').update('noise').digest();
+
+    const sig = sign('SHA256', testData, privateKey as string);
+    const valid = verify('SHA256', testData, publicKey as string, sig);
+    expect(valid).to.equal(true, `iteration ${i} failed`);
+  }
+});


### PR DESCRIPTION
## Summary

Adds regression tests for [#118](https://github.com/margelo/react-native-quick-crypto/issues/118) — `sign()` failing with "Failed to read private key" after calling other crypto operations due to OpenSSL error queue pollution.

## Analysis: Why #118 Is Resolved

The original bug was caused by **OpenSSL error queue pollution**. OpenSSL maintains a per-thread error queue — when crypto operations like `pbkdf2Sync()` run, they can leave stale errors in the queue. If `sign()` then parses a private key without first clearing that queue, the stale errors cause `EVP_PKEY` parsing to fail with "Failed to read private key", even though the key is perfectly valid.

Since #118 was filed, the entire native layer has been rewritten. The fix is **defensive `ERR_clear_error()` calls before every key parsing operation** in [`KeyObjectData.cpp`](https://github.com/margelo/react-native-quick-crypto/blob/main/packages/react-native-quick-crypto/cpp/keys/KeyObjectData.cpp):

- **Line 38** — before `TryParsePrivateKey()` (PEM private key path)
- **Line 138** — before `TryParsePrivateKey()` in `GetPublicOrPrivateKey()` (PKCS8/SEC1/PKCS1 fallback)
- **Line 161** — before the second `TryParsePrivateKey()` attempt (PEM auto-detect path)
- **Line 239** — before `TryParsePrivateKey()` in `GetPrivateKey()` (DER private key path)

Additionally, the utility helper [`getOpenSSLError()`](https://github.com/margelo/react-native-quick-crypto/blob/main/cpp/utils/QuickCryptoUtils.hpp#L17-L24) now drains and clears the error queue after retrieving an error message, preventing residual pollution.

This directly addresses the root cause: no matter what crypto operations ran before `sign()`, the error queue is always clean when key parsing begins.

## Changes

- New test file `example/src/tests/keys/sign_verify_error_queue.ts` with 7 regression tests:
  - `sign` after `pbkdf2Sync` (repeated)
  - `sign` after `createHash` (repeated)
  - `sign` after `createHmac` (repeated)
  - `sign` after AES cipher/decipher (repeated)
  - `sign` after mixed crypto operations (repeated)
  - Ed25519 `sign` after mixed crypto operations
  - ECDSA `sign` after mixed crypto operations
- Each test runs 10 iterations to catch intermittent error queue pollution
- Registered test file in `useTestsList.ts`

## Testing

Run the `keys.sign/verify` test suite in the example app. All 7 new tests should pass.

Closes #118