### PR TITLE
fix: add JS-side validation for pbkdf2 iterations/keylen

### DIFF
--- a/example/src/tests/pbkdf2/pbkdf2_tests.ts
+++ b/example/src/tests/pbkdf2/pbkdf2_tests.ts
@@ -195,8 +195,21 @@ algos.forEach(function (algorithm) {
     });
   });
 
-  // TODO(#931): enable invalid fixture tests once JS-side validation is added
-  // for iterations/keylen. Currently invalid values (negative, NaN, Infinity)
-  // reach the native C layer and trigger assert()/abort() instead of throwing.
-  // See: fixtures.invalid
+  fixtures.invalid.forEach(function (f) {
+    test(
+      SUITE,
+      `invalid: ${algorithm} throws "${f.exception}" for iterations=${f.iterations} keylen=${f.dkLen}`,
+      () => {
+        expect(() => {
+          crypto.pbkdf2Sync(
+            f.key as string,
+            f.salt as string,
+            f.iterations as number,
+            f.dkLen as number,
+            algorithm,
+          );
+        }).to.throw(f.exception);
+      },
+    );
+  });
 });

--- a/packages/react-native-quick-crypto/src/pbkdf2.ts
+++ b/packages/react-native-quick-crypto/src/pbkdf2.ts
@@ -31,6 +31,33 @@ function getNative(): Pbkdf2 {
   return native;
 }
 
+const MAX_INT32 = 2147483647;
+
+function validateParameters(iterations: number, keylen: number): void {
+  if (typeof iterations !== 'number') {
+    throw new TypeError('Iterations not a number');
+  }
+  if (typeof keylen !== 'number') {
+    throw new TypeError('Key length not a number');
+  }
+  if (
+    iterations < 1 ||
+    !Number.isFinite(iterations) ||
+    !Number.isInteger(iterations) ||
+    iterations > MAX_INT32
+  ) {
+    throw new TypeError('Bad iterations');
+  }
+  if (
+    keylen < 0 ||
+    !Number.isFinite(keylen) ||
+    !Number.isInteger(keylen) ||
+    keylen > MAX_INT32
+  ) {
+    throw new TypeError('Bad key length');
+  }
+}
+
 function sanitizeInput(input: BinaryLike, errorMsg: string): ArrayBuffer {
   try {
     return binaryLikeToArrayBuffer(input);
@@ -51,6 +78,7 @@ export function pbkdf2(
   if (callback === undefined || typeof callback !== 'function') {
     throw new Error('No callback provided to pbkdf2');
   }
+  validateParameters(iterations, keylen);
   const sanitizedPassword = sanitizeInput(password, WRONG_PASS);
   const sanitizedSalt = sanitizeInput(salt, WRONG_SALT);
   const normalizedDigest = normalizeHashName(digest, HashContext.Node);
@@ -81,6 +109,7 @@ export function pbkdf2Sync(
   keylen: number,
   digest: string,
 ): Buffer {
+  validateParameters(iterations, keylen);
   const sanitizedPassword = sanitizeInput(password, WRONG_PASS);
   const sanitizedSalt = sanitizeInput(salt, WRONG_SALT);
 


### PR DESCRIPTION
## Summary

Adds JavaScript-side parameter validation for `pbkdf2` and `pbkdf2Sync` to prevent invalid values from reaching the native C++ layer where they trigger `assert()`/`abort()` instead of throwing catchable JS errors.

## Changes

- Add `validateParameters()` function in `packages/react-native-quick-crypto/src/pbkdf2.ts` that validates `iterations` and `keylen` before calling native code:
  - Must be a number (not a string)
  - Must be a finite integer (rejects NaN, Infinity, floats)
  - `iterations` must be `>= 1` and `<= INT32_MAX`
  - `keylen` must be `>= 0` and `<= INT32_MAX`
- Enable previously-disabled invalid fixture tests in `example/src/tests/pbkdf2/pbkdf2_tests.ts`

## Testing

Invalid fixture tests cover: string iterations, negative iterations, string dkLen, negative dkLen, huge dkLen (`4073741824`), `NaN` dkLen, and `Infinity` dkLen.

Fixes #931