### PR TITLE
fix: expo plugin sodium not working on SDK 55+

### DIFF
--- a/packages/react-native-quick-crypto/src/expo-plugin/withSodiumIos.ts
+++ b/packages/react-native-quick-crypto/src/expo-plugin/withSodiumIos.ts
@@ -14,13 +14,8 @@ export const withSodiumIos: ConfigPlugin<ConfigProps> = config => {
       );
       let contents = fs.readFileSync(podfilePath, 'utf-8');
 
-      // Check if SODIUM_ENABLED is already set
       if (!contents.includes("ENV['SODIUM_ENABLED']")) {
-        // Add it right after the RCT_NEW_ARCH_ENABLED ENV variable
-        contents = contents.replace(
-          /^(ENV\['RCT_NEW_ARCH_ENABLED'\].*$)/m,
-          `$1\nENV['SODIUM_ENABLED'] = '1'`,
-        );
+        contents = `ENV['SODIUM_ENABLED'] = '1'\n${contents}`;
         fs.writeFileSync(podfilePath, contents);
       }
 


### PR DESCRIPTION
## Summary

Fixes the Expo config plugin for enabling libsodium on iOS. The plugin was failing on Expo SDK 55+ because it relied on a regex match against the `RCT_NEW_ARCH_ENABLED` ENV line in the Podfile, which no longer exists in newer SDK versions.

## Changes

- Replaced the fragile regex-based insertion with a simple prepend to the top of the Podfile
- Removed unnecessary comments
- Net reduction of 5 lines

## Testing

- Verify `ENV['SODIUM_ENABLED'] = '1'` appears at the top of the generated Podfile after running `npx expo prebuild --platform ios`
- Confirm libsodium is included in the iOS build

Fixes #957