### PR TITLE
fix: cast getRandomValues result and fix CI tsc error detection

### DIFF
--- a/.github/workflows/validate-js.yml
+++ b/.github/workflows/validate-js.yml
@@ -48,7 +48,8 @@ jobs:
 
       - name: Run TypeScript # Reviewdog tsc errorformat: %f:%l:%c - error TS%n: %m
         run: |
-          bun tsc | reviewdog -name="tsc" -efm="%f(%l,%c): error TS%n: %m" -reporter="github-pr-review" -filter-mode="nofilter" -fail-on-error -tee
+          set -o pipefail
+          bun tsc 2>&1 | sed 's/^[^ ]* typescript: //' | reviewdog -name="tsc" -efm="%f(%l,%c): error TS%n: %m" -reporter="github-pr-review" -filter-mode="nofilter" -fail-on-error -tee
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/example/src/tests/subtle/wrap_unwrap.ts
+++ b/example/src/tests/subtle/wrap_unwrap.ts
@@ -41,7 +41,7 @@ test(SUITE, 'wrap/unwrap AES-256 with AES-KW', async () => {
   );
 
   // Verify keys are functionally identical
-  const plaintext = getRandomValues(new Uint8Array(32));
+  const plaintext = getRandomValues(new Uint8Array(32)) as Uint8Array;
   const iv = getRandomValues(new Uint8Array(12));
 
   const ct1 = await subtle.encrypt(
@@ -184,7 +184,7 @@ test(SUITE, 'wrap/unwrap with AES-CBC', async () => {
     ['encrypt', 'decrypt'],
   );
 
-  const plaintext = getRandomValues(new Uint8Array(32));
+  const plaintext = getRandomValues(new Uint8Array(32)) as Uint8Array;
   const gcmIv = getRandomValues(new Uint8Array(12));
 
   const ct = await subtle.encrypt(
@@ -237,7 +237,7 @@ test(SUITE, 'wrap/unwrap with AES-OCB', async () => {
     ['encrypt', 'decrypt'],
   );
 
-  const plaintext = getRandomValues(new Uint8Array(32));
+  const plaintext = getRandomValues(new Uint8Array(32)) as Uint8Array;
   const gcmIv = getRandomValues(new Uint8Array(12));
 
   const ct = await subtle.encrypt(
@@ -343,7 +343,7 @@ test(SUITE, 'wrap/unwrap with RSA-OAEP', async () => {
     ['encrypt', 'decrypt'],
   );
 
-  const plaintext = getRandomValues(new Uint8Array(32));
+  const plaintext = getRandomValues(new Uint8Array(32)) as Uint8Array;
   const iv = getRandomValues(new Uint8Array(12));
 
   const ct = await subtle.encrypt(
@@ -396,7 +396,7 @@ test(SUITE, 'wrap/unwrap with ChaCha20-Poly1305', async () => {
     ['encrypt', 'decrypt'],
   );
 
-  const plaintext = getRandomValues(new Uint8Array(32));
+  const plaintext = getRandomValues(new Uint8Array(32)) as Uint8Array;
   const gcmIv = getRandomValues(new Uint8Array(12));
 
   const ct = await subtle.encrypt(


### PR DESCRIPTION
## Summary

Fixes the failed 1.0.16 release — npm published successfully but the git tag/release step failed because the pre-commit hook caught TS errors.

- **TS fix**: `wrap_unwrap.ts` calls `Buffer.from(plaintext)` where `plaintext` is `getRandomValues()` return type (`RandomTypedArrays` union). `@craftzdog/react-native-buffer`'s `Buffer.from()` only accepts `Buffer | Uint8Array`, not the full union. Cast to `Uint8Array` at the 5 call sites since we always pass `new Uint8Array()` in.

- **CI fix**: `bun --filter='*' typescript` prefixes output with workspace names (e.g. `react-native-quick-crypto-example typescript: src/file.ts(60,17): error TS2769: ...`), which breaks reviewdog's `-efm` pattern. Errors were being silently ignored. Added `set -o pipefail` to propagate tsc exit codes and `sed` to strip the workspace prefix so reviewdog can parse errors.

## Test plan

- [x] `bun tsc` passes locally
- [x] Pre-commit hook passes (lint-staged + tsc + bob build)
- [ ] CI Validate JS workflow passes
- [ ] After merge: complete 1.0.16 git release (version bump, tag, GitHub release)