### PR TITLE
fix: Improve Hash.digest(encoding) TypeScript return type

### DIFF
--- a/packages/react-native-quick-crypto/src/hash.ts
+++ b/packages/react-native-quick-crypto/src/hash.ts
@@ -299,6 +299,12 @@ const internalDigest = (
 export function hash(
   algorithm: string,
   data: BinaryLike,
+  outputEncoding: Encoding,
+): string;
+export function hash(algorithm: string, data: BinaryLike): Buffer;
+export function hash(
+  algorithm: string,
+  data: BinaryLike,
   outputEncoding?: Encoding,
 ): string | Buffer {
   const h = createHash(algorithm);


### PR DESCRIPTION
## Summary

This PR improves TypeScript typings in `src/hash.ts` (no runtime behaviour changes)

### 1) Fix `Hash.digest(encoding)` return type

`Hash.digest(encoding)` is typed as `Buffer`, but it returns a string when `encoding` param is provided

```
createHash(...).update(...).digest('base64') // returns Buffer type, not a string type
```

This appears to be a typo, cuz similar APIs in this package (Blake3.digest() and Hmac.digest()) return string type when `encoding` is provided

### 2) Improve `hash()` return type precision

Added overloads for `hash()` function, so return type depends on outputEncoding:
- `hash(algorithm, data, outputEncoding)` -> `string`
- `hash(algorithm, data)` -> `Buffer`

Before, the return type was always `string | Buffer`