### PR TITLE
chore(deps): Bump minimum requirement of nitro to 0.31.2 (peerDeps only)

### DIFF
--- a/packages/react-native-quick-crypto/package.json
+++ b/packages/react-native-quick-crypto/package.json
@@ -98,7 +98,7 @@
   "peerDependencies": {
     "react": "*",
     "react-native": "*",
-    "react-native-nitro-modules": ">=0.29.1",
+    "react-native-nitro-modules": ">=0.31.2",
     "react-native-quick-base64": ">=2.1.0",
     "expo": ">=48.0.0",
     "expo-build-properties": "*"


### PR DESCRIPTION
Required for #976
I tested the new minimum nitro version with **corresponding** nitrogen/generated code and it works.