### PR TITLE
ci: trigger E2E iOS/Android on deps/** changes

### DIFF
--- a/.github/workflows/e2e-android-test.yml
+++ b/.github/workflows/e2e-android-test.yml
@@ -11,6 +11,7 @@ on:
       - '.github/workflows/e2e-android-test.yml'
       - 'example/**'
       - 'packages/react-native-quick-crypto/cpp/**'
+      - 'packages/react-native-quick-crypto/deps/**'
       - 'packages/react-native-quick-crypto/nitrogen/**'
       - 'packages/react-native-quick-crypto/src/**'
       - 'packages/react-native-quick-crypto/android/**'
@@ -19,6 +20,7 @@ on:
     paths:
       - 'example/**'
       - 'packages/react-native-quick-crypto/cpp/**'
+      - 'packages/react-native-quick-crypto/deps/**'
       - 'packages/react-native-quick-crypto/nitrogen/**'
       - 'packages/react-native-quick-crypto/src/**'
       - 'packages/react-native-quick-crypto/android/**'

--- a/.github/workflows/e2e-ios-test.yml
+++ b/.github/workflows/e2e-ios-test.yml
@@ -11,6 +11,7 @@ on:
       - '.github/workflows/e2e-ios-test.yml'
       - 'example/**'
       - 'packages/react-native-quick-crypto/cpp/**'
+      - 'packages/react-native-quick-crypto/deps/**'
       - 'packages/react-native-quick-crypto/nitrogen/**'
       - 'packages/react-native-quick-crypto/src/**'
       - 'packages/react-native-quick-crypto/ios/**'
@@ -19,6 +20,7 @@ on:
     paths:
       - 'example/**'
       - 'packages/react-native-quick-crypto/cpp/**'
+      - 'packages/react-native-quick-crypto/deps/**'
       - 'packages/react-native-quick-crypto/nitrogen/**'
       - 'packages/react-native-quick-crypto/src/**'
       - 'packages/react-native-quick-crypto/ios/**'


### PR DESCRIPTION
## Summary
Adds `packages/react-native-quick-crypto/deps/**` to the path filters on `e2e-ios-test.yml` and `e2e-android-test.yml` so that submodule pointer bumps actually trigger the E2E suites that are supposed to validate them.

This was surfaced by #1011 (BLAKE3 1.8.5) and #1012 (ncrypto v1.1.4): both opened with zero CI signal because the existing path filters only watch `cpp/`, `nitrogen/`, `src/`, and `ios/` / `android/`. Submodule changes live under `deps/` and were silently ignored.

## Changes
- `.github/workflows/e2e-ios-test.yml`: add `packages/react-native-quick-crypto/deps/**` to both `pull_request.paths` and `push.paths`
- `.github/workflows/e2e-android-test.yml`: same

Intentionally **not** touching `validate-cpp.yml` or `validate-js.yml` — those lint our own sources, not vendored upstream code, and would just be noise on a dep bump.

## Testing
- `bun tsc --noEmit` clean (pre-commit hook covered this)
- The real verification is meta: after this lands, push an empty/no-op commit to the `deps/blake3-1.8.5` and `deps/ncrypto-bump` branches and confirm the E2E workflows now appear in `gh pr checks`. (`pull_request` events use the workflow definition from the **base** branch at event time, so this PR has to merge first before it influences other PRs.)

## Issue references
None directly — exposed by #1011 / #1012 but doesn't close them.