### PR TITLE
feat(perf): Remove unnecessary construction of native ArrayBuffer

### DIFF
--- a/packages/react-native-quick-crypto/cpp/cipher/CCMCipher.cpp
+++ b/packages/react-native-quick-crypto/cpp/cipher/CCMCipher.cpp
@@ -18,8 +18,7 @@ void CCMCipher::init(const std::shared_ptr<ArrayBuffer> cipher_key, const std::s
   checkCtx();
 
   // 2. Perform CCM-specific initialization
-  auto native_iv = ToNativeArrayBuffer(iv);
-  size_t iv_len = native_iv->size();
+  size_t iv_len = iv->size();
 
   // Set the IV length using CCM-specific control
   if (EVP_CIPHER_CTX_ctrl(ctx.get(), EVP_CTRL_CCM_SET_IVLEN, iv_len, nullptr) != 1) {
@@ -39,9 +38,8 @@ void CCMCipher::init(const std::shared_ptr<ArrayBuffer> cipher_key, const std::s
   }
 
   // Finally, initialize the key and IV using the parameters passed to this function.
-  auto native_key = ToNativeArrayBuffer(cipher_key); // Use 'cipher_key' parameter
-  const unsigned char* key_ptr = reinterpret_cast<const unsigned char*>(native_key->data());
-  const unsigned char* iv_ptr = reinterpret_cast<const unsigned char*>(native_iv->data());
+  const unsigned char* key_ptr = reinterpret_cast<const unsigned char*>(cipher_key->data());
+  const unsigned char* iv_ptr = reinterpret_cast<const unsigned char*>(iv->data());
 
   // The last argument (is_cipher) should be consistent with the initial setup call.
   if (EVP_CipherInit_ex(ctx.get(), nullptr, nullptr, key_ptr, iv_ptr, is_cipher) != 1) {
@@ -56,8 +54,7 @@ std::shared_ptr<ArrayBuffer> CCMCipher::update(const std::shared_ptr<ArrayBuffer
   checkCtx();
   checkNotFinalized();
   has_update_called = true;
-  auto native_data = ToNativeArrayBuffer(data);
-  size_t in_len = native_data->size();
+  size_t in_len = data->size();
   if (in_len < 0 || in_len > INT_MAX) {
     throw std::runtime_error("Invalid message length");
   }
@@ -77,7 +74,7 @@ std::shared_ptr<ArrayBuffer> CCMCipher::update(const std::shared_ptr<ArrayBuffer
   }
 
   auto out_buf = std::make_unique<unsigned char[]>(out_len);
-  const uint8_t* in = reinterpret_cast<const uint8_t*>(native_data->data());
+  const uint8_t* in = reinterpret_cast<const uint8_t*>(data->data());
 
   int actual_out_len = 0;
   int ret = EVP_CipherUpdate(ctx.get(), out_buf.get(), &actual_out_len, in, in_len);
@@ -185,8 +182,7 @@ bool CCMCipher::setAAD(const std::shared_ptr<ArrayBuffer>& data, std::optional<d
   int out_len = 0;
 
   // Get AAD data and length *before* deciding whether to set total length
-  auto native_aad = ToNativeArrayBuffer(data);
-  size_t aad_len = native_aad->size();
+  size_t aad_len = data->size();
 
   // 1. Set the total *ciphertext* length. This seems necessary based on examples,
   //    BUT the wiki says "(only needed if AAD is passed)". Let's skip if decrypting and AAD length is 0.
@@ -203,7 +199,7 @@ bool CCMCipher::setAAD(const std::shared_ptr<ArrayBuffer>& data, std::optional<d
   // 2. Process AAD Data
   // Per OpenSSL CCM decryption examples, this MUST be called even if aad_len is 0.
   // Pass nullptr as the output buffer, the AAD data pointer, and its length.
-  if (EVP_CipherUpdate(ctx.get(), nullptr, &out_len, native_aad->data(), aad_len) != 1) {
+  if (EVP_CipherUpdate(ctx.get(), nullptr, &out_len, data->data(), aad_len) != 1) {
     unsigned long err = ERR_get_error();
     char err_buf[256];
     ERR_error_string_n(err, err_buf, sizeof(err_buf));

--- a/packages/react-native-quick-crypto/cpp/cipher/ChaCha20Cipher.cpp
+++ b/packages/react-native-quick-crypto/cpp/cipher/ChaCha20Cipher.cpp
@@ -32,21 +32,18 @@ void ChaCha20Cipher::init(const std::shared_ptr<ArrayBuffer> cipher_key, const s
   }
 
   // Set key and IV
-  auto native_key = ToNativeArrayBuffer(cipher_key);
-  auto native_iv = ToNativeArrayBuffer(iv);
-
   // Validate key size
-  if (native_key->size() != kKeySize) {
+  if (cipher_key->size() != kKeySize) {
     throw std::runtime_error("ChaCha20 key must be 32 bytes");
   }
 
   // Validate IV size
-  if (native_iv->size() != kIVSize) {
+  if (iv->size() != kIVSize) {
     throw std::runtime_error("ChaCha20 IV must be 16 bytes");
   }
 
-  const unsigned char* key_ptr = reinterpret_cast<const unsigned char*>(native_key->data());
-  const unsigned char* iv_ptr = reinterpret_cast<const unsigned char*>(native_iv->data());
+  const unsigned char* key_ptr = reinterpret_cast<const unsigned char*>(cipher_key->data());
+  const unsigned char* iv_ptr = reinterpret_cast<const unsigned char*>(iv->data());
 
   if (EVP_CipherInit_ex(ctx.get(), nullptr, nullptr, key_ptr, iv_ptr, is_cipher) != 1) {
     unsigned long err = ERR_get_error();
@@ -60,8 +57,7 @@ void ChaCha20Cipher::init(const std::shared_ptr<ArrayBuffer> cipher_key, const s
 std::shared_ptr<ArrayBuffer> ChaCha20Cipher::update(const std::shared_ptr<ArrayBuffer>& data) {
   checkCtx();
   checkNotFinalized();
-  auto native_data = ToNativeArrayBuffer(data);
-  size_t in_len = native_data->size();
+  size_t in_len = data->size();
   if (in_len > INT_MAX) {
     throw std::runtime_error("Message too long");
   }
@@ -71,7 +67,7 @@ std::shared_ptr<ArrayBuffer> ChaCha20Cipher::update(const std::shared_ptr<ArrayB
   auto out_buf = std::make_unique<uint8_t[]>(out_len);
 
   // Perform the cipher update operation
-  if (EVP_CipherUpdate(ctx.get(), out_buf.get(), &out_len, native_data->data(), in_len) != 1) {
+  if (EVP_CipherUpdate(ctx.get(), out_buf.get(), &out_len, data->data(), in_len) != 1) {
     unsigned long err = ERR_get_error();
     char err_buf[256];
     ERR_error_string_n(err, err_buf, sizeof(err_buf));

--- a/packages/react-native-quick-crypto/cpp/cipher/ChaCha20Poly1305Cipher.cpp
+++ b/packages/react-native-quick-crypto/cpp/cipher/ChaCha20Poly1305Cipher.cpp
@@ -32,21 +32,18 @@ void ChaCha20Poly1305Cipher::init(const std::shared_ptr<ArrayBuffer> cipher_key,
   }
 
   // Set key and IV
-  auto native_key = ToNativeArrayBuffer(cipher_key);
-  auto native_iv = ToNativeArrayBuffer(iv);
-
   // Validate key size
-  if (native_key->size() != kKeySize) {
+  if (cipher_key->size() != kKeySize) {
     throw std::runtime_error("ChaCha20-Poly1305 key must be 32 bytes");
   }
 
   // Validate nonce size
-  if (native_iv->size() != kNonceSize) {
+  if (iv->size() != kNonceSize) {
     throw std::runtime_error("ChaCha20-Poly1305 nonce must be 12 bytes");
   }
 
-  const unsigned char* key_ptr = reinterpret_cast<const unsigned char*>(native_key->data());
-  const unsigned char* iv_ptr = reinterpret_cast<const unsigned char*>(native_iv->data());
+  const unsigned char* key_ptr = reinterpret_cast<const unsigned char*>(cipher_key->data());
+  const unsigned char* iv_ptr = reinterpret_cast<const unsigned char*>(iv->data());
 
   if (EVP_CipherInit_ex(ctx.get(), nullptr, nullptr, key_ptr, iv_ptr, is_cipher) != 1) {
     unsigned long err = ERR_get_error();
@@ -66,8 +63,7 @@ std::shared_ptr<ArrayBuffer> ChaCha20Poly1305Cipher::update(const std::shared_pt
   checkCtx();
   checkNotFinalized();
   has_update_called = true;
-  auto native_data = ToNativeArrayBuffer(data);
-  size_t in_len = native_data->size();
+  size_t in_len = data->size();
   if (in_len > INT_MAX) {
     throw std::runtime_error("Message too long");
   }
@@ -77,7 +73,7 @@ std::shared_ptr<ArrayBuffer> ChaCha20Poly1305Cipher::update(const std::shared_pt
   auto out_buf = std::make_unique<uint8_t[]>(out_len);
 
   // Perform the cipher update operation
-  if (EVP_CipherUpdate(ctx.get(), out_buf.get(), &out_len, native_data->data(), in_len) != 1) {
+  if (EVP_CipherUpdate(ctx.get(), out_buf.get(), &out_len, data->data(), in_len) != 1) {
     unsigned long err = ERR_get_error();
     char err_buf[256];
     ERR_error_string_n(err, err_buf, sizeof(err_buf));
@@ -121,12 +117,11 @@ std::shared_ptr<ArrayBuffer> ChaCha20Poly1305Cipher::final() {
 bool ChaCha20Poly1305Cipher::setAAD(const std::shared_ptr<ArrayBuffer>& data, std::optional<double> plaintextLength) {
   checkCtx();
   checkAADBeforeUpdate();
-  auto native_aad = ToNativeArrayBuffer(data);
-  size_t aad_len = native_aad->size();
+  size_t aad_len = data->size();
 
   // Set AAD data
   int out_len = 0;
-  if (EVP_CipherUpdate(ctx.get(), nullptr, &out_len, native_aad->data(), aad_len) != 1) {
+  if (EVP_CipherUpdate(ctx.get(), nullptr, &out_len, data->data(), aad_len) != 1) {
     unsigned long err = ERR_get_error();
     char err_buf[256];
     ERR_error_string_n(err, err_buf, sizeof(err_buf));
@@ -163,12 +158,11 @@ bool ChaCha20Poly1305Cipher::setAuthTag(const std::shared_ptr<ArrayBuffer>& tag)
     throw std::runtime_error("setAuthTag can only be called during decryption");
   }
 
-  auto native_tag = ToNativeArrayBuffer(tag);
-  if (native_tag->size() != kTagSize) {
+  if (tag->size() != kTagSize) {
     throw std::runtime_error("ChaCha20-Poly1305 tag must be 16 bytes");
   }
 
-  if (EVP_CIPHER_CTX_ctrl(ctx.get(), EVP_CTRL_AEAD_SET_TAG, kTagSize, native_tag->data()) != 1) {
+  if (EVP_CIPHER_CTX_ctrl(ctx.get(), EVP_CTRL_AEAD_SET_TAG, kTagSize, tag->data()) != 1) {
     unsigned long err = ERR_get_error();
     char err_buf[256];
     ERR_error_string_n(err, err_buf, sizeof(err_buf));

--- a/packages/react-native-quick-crypto/cpp/cipher/GCMCipher.cpp
+++ b/packages/react-native-quick-crypto/cpp/cipher/GCMCipher.cpp
@@ -37,8 +37,7 @@ void GCMCipher::init(const std::shared_ptr<ArrayBuffer> cipher_key, const std::s
   }
 
   // 4. Set IV length for non-standard IV sizes (GCM default is 96 bits/12 bytes)
-  auto native_iv = ToNativeArrayBuffer(iv);
-  size_t iv_len = native_iv->size();
+  size_t iv_len = iv->size();
 
   if (iv_len != 12) { // Only set if not the default length
     if (EVP_CIPHER_CTX_ctrl(ctx.get(), EVP_CTRL_GCM_SET_IVLEN, static_cast<int>(iv_len), nullptr) != 1) {
@@ -51,9 +50,8 @@ void GCMCipher::init(const std::shared_ptr<ArrayBuffer> cipher_key, const std::s
   }
 
   // 5. Now set the key and IV
-  auto native_key = ToNativeArrayBuffer(cipher_key);
-  const unsigned char* key_ptr = reinterpret_cast<const unsigned char*>(native_key->data());
-  const unsigned char* iv_ptr = reinterpret_cast<const unsigned char*>(native_iv->data());
+  const unsigned char* key_ptr = reinterpret_cast<const unsigned char*>(cipher_key->data());
+  const unsigned char* iv_ptr = reinterpret_cast<const unsigned char*>(iv->data());
 
   if (EVP_CipherInit_ex(ctx.get(), nullptr, nullptr, key_ptr, iv_ptr, is_cipher) != 1) {
     unsigned long err = ERR_get_error();

--- a/packages/react-native-quick-crypto/cpp/cipher/HybridCipher.cpp
+++ b/packages/react-native-quick-crypto/cpp/cipher/HybridCipher.cpp
@@ -83,10 +83,8 @@ void HybridCipher::init(const std::shared_ptr<ArrayBuffer> cipher_key, const std
 
   // For base hybrid cipher, set key and IV immediately.
   // Derived classes like CCM might override init and handle this differently.
-  auto native_key = ToNativeArrayBuffer(cipher_key);
-  auto native_iv = ToNativeArrayBuffer(iv);
-  const unsigned char* key_ptr = reinterpret_cast<const unsigned char*>(native_key->data());
-  const unsigned char* iv_ptr = reinterpret_cast<const unsigned char*>(native_iv->data());
+  const unsigned char* key_ptr = reinterpret_cast<const unsigned char*>(cipher_key->data());
+  const unsigned char* iv_ptr = reinterpret_cast<const unsigned char*>(iv->data());
 
   if (EVP_CipherInit_ex(ctx.get(), nullptr, nullptr, key_ptr, iv_ptr, is_cipher) != 1) {
     unsigned long err = ERR_get_error();
@@ -106,11 +104,10 @@ void HybridCipher::init(const std::shared_ptr<ArrayBuffer> cipher_key, const std
 }
 
 std::shared_ptr<ArrayBuffer> HybridCipher::update(const std::shared_ptr<ArrayBuffer>& data) {
-  auto native_data = ToNativeArrayBuffer(data);
   checkCtx();
   checkNotFinalized();
   has_update_called = true;
-  size_t in_len = native_data->size();
+  size_t in_len = data->size();
   if (in_len > INT_MAX) {
     throw std::runtime_error("Message too long");
   }
@@ -119,7 +116,7 @@ std::shared_ptr<ArrayBuffer> HybridCipher::update(const std::shared_ptr<ArrayBuf
   auto out_buf = std::make_unique<uint8_t[]>(out_len);
   // Perform the cipher update operation. The real size of the output is
   // returned in out_len
-  int ret = EVP_CipherUpdate(ctx.get(), out_buf.get(), &out_len, native_data->data(), in_len);
+  int ret = EVP_CipherUpdate(ctx.get(), out_buf.get(), &out_len, data->data(), in_len);
 
   if (!ret) {
     unsigned long err = ERR_get_error();
@@ -168,11 +165,9 @@ std::shared_ptr<ArrayBuffer> HybridCipher::final() {
 bool HybridCipher::setAAD(const std::shared_ptr<ArrayBuffer>& data, std::optional<double> plaintextLength) {
   checkCtx();
   checkAADBeforeUpdate();
-  auto native_data = ToNativeArrayBuffer(data);
-
   // Set the AAD
   int out_len;
-  if (!EVP_CipherUpdate(ctx.get(), nullptr, &out_len, native_data->data(), native_data->size())) {
+  if (!EVP_CipherUpdate(ctx.get(), nullptr, &out_len, data->data(), data->size())) {
     return false;
   }
 
@@ -192,9 +187,8 @@ bool HybridCipher::setAuthTag(const std::shared_ptr<ArrayBuffer>& tag) {
     throw std::runtime_error("setAuthTag can only be called during decryption.");
   }
 
-  auto native_tag = ToNativeArrayBuffer(tag);
-  size_t tag_len = native_tag->size();
-  uint8_t* tag_ptr = native_tag->data();
+  size_t tag_len = tag->size();
+  uint8_t* tag_ptr = tag->data();
 
   int mode = EVP_CIPHER_CTX_mode(ctx.get());
 

--- a/packages/react-native-quick-crypto/cpp/cipher/HybridRsaCipher.cpp
+++ b/packages/react-native-quick-crypto/cpp/cipher/HybridRsaCipher.cpp
@@ -102,15 +102,14 @@ std::shared_ptr<ArrayBuffer> HybridRsaCipher::encrypt(const std::shared_ptr<Hybr
     }
 
     if (label.has_value() && label.value()->size() > 0) {
-      auto native_label = ToNativeArrayBuffer(label.value());
-      unsigned char* label_copy = (unsigned char*)OPENSSL_malloc(native_label->size());
+      unsigned char* label_copy = (unsigned char*)OPENSSL_malloc(label.value()->size());
       if (!label_copy) {
         EVP_PKEY_CTX_free(ctx);
         throw std::runtime_error("Failed to allocate memory for label");
       }
-      std::memcpy(label_copy, native_label->data(), native_label->size());
+      std::memcpy(label_copy, label.value()->data(), label.value()->size());
 
-      if (EVP_PKEY_CTX_set0_rsa_oaep_label(ctx, label_copy, native_label->size()) <= 0) {
+      if (EVP_PKEY_CTX_set0_rsa_oaep_label(ctx, label_copy, label.value()->size()) <= 0) {
         OPENSSL_free(label_copy);
         EVP_PKEY_CTX_free(ctx);
         throw std::runtime_error("Failed to set OAEP label");
@@ -118,9 +117,8 @@ std::shared_ptr<ArrayBuffer> HybridRsaCipher::encrypt(const std::shared_ptr<Hybr
     }
   }
 
-  auto native_data = ToNativeArrayBuffer(data);
-  const unsigned char* in = native_data->data();
-  size_t inlen = native_data->size();
+  const unsigned char* in = data->data();
+  size_t inlen = data->size();
 
   size_t outlen;
   if (EVP_PKEY_encrypt(ctx, nullptr, &outlen, in, inlen) <= 0) {
@@ -197,15 +195,14 @@ std::shared_ptr<ArrayBuffer> HybridRsaCipher::decrypt(const std::shared_ptr<Hybr
     }
 
     if (label.has_value() && label.value()->size() > 0) {
-      auto native_label = ToNativeArrayBuffer(label.value());
-      unsigned char* label_copy = (unsigned char*)OPENSSL_malloc(native_label->size());
+      unsigned char* label_copy = (unsigned char*)OPENSSL_malloc(label.value()->size());
       if (!label_copy) {
         EVP_PKEY_CTX_free(ctx);
         throw std::runtime_error("Failed to allocate memory for label");
       }
-      std::memcpy(label_copy, native_label->data(), native_label->size());
+      std::memcpy(label_copy, label.value()->data(), label.value()->size());
 
-      if (EVP_PKEY_CTX_set0_rsa_oaep_label(ctx, label_copy, native_label->size()) <= 0) {
+      if (EVP_PKEY_CTX_set0_rsa_oaep_label(ctx, label_copy, label.value()->size()) <= 0) {
         OPENSSL_free(label_copy);
         EVP_PKEY_CTX_free(ctx);
         throw std::runtime_error("Failed to set OAEP label");
@@ -213,9 +210,8 @@ std::shared_ptr<ArrayBuffer> HybridRsaCipher::decrypt(const std::shared_ptr<Hybr
     }
   }
 
-  auto native_data = ToNativeArrayBuffer(data);
-  const unsigned char* in = native_data->data();
-  size_t inlen = native_data->size();
+  const unsigned char* in = data->data();
+  size_t inlen = data->size();
 
   // Both decrypt calls below operate on attacker-controlled ciphertext, so
   // any failure must be surfaced with an opaque, content-independent message.
@@ -269,9 +265,8 @@ std::shared_ptr<ArrayBuffer> HybridRsaCipher::publicDecrypt(const std::shared_pt
     throw std::runtime_error("Failed to set RSA padding");
   }
 
-  auto native_data = ToNativeArrayBuffer(data);
-  const unsigned char* in = native_data->data();
-  size_t inlen = native_data->size();
+  const unsigned char* in = data->data();
+  size_t inlen = data->size();
 
   // verify_recover acts on attacker-controlled ciphertext too — surface only
   // an opaque error so a remote caller cannot distinguish failure modes.
@@ -351,9 +346,8 @@ std::shared_ptr<ArrayBuffer> HybridRsaCipher::privateEncrypt(const std::shared_p
     throw std::runtime_error("Failed to set RSA padding");
   }
 
-  auto native_data = ToNativeArrayBuffer(data);
-  const unsigned char* in = native_data->data();
-  size_t inlen = native_data->size();
+  const unsigned char* in = data->data();
+  size_t inlen = data->size();
 
   size_t outlen;
   if (EVP_PKEY_sign(ctx, nullptr, &outlen, in, inlen) <= 0) {
@@ -430,15 +424,14 @@ std::shared_ptr<ArrayBuffer> HybridRsaCipher::privateDecrypt(const std::shared_p
     }
 
     if (label.has_value() && label.value()->size() > 0) {
-      auto native_label = ToNativeArrayBuffer(label.value());
-      unsigned char* label_copy = (unsigned char*)OPENSSL_malloc(native_label->size());
+      unsigned char* label_copy = (unsigned char*)OPENSSL_malloc(label.value()->size());
       if (!label_copy) {
         EVP_PKEY_CTX_free(ctx);
         throw std::runtime_error("Failed to allocate memory for label");
       }
-      std::memcpy(label_copy, native_label->data(), native_label->size());
+      std::memcpy(label_copy, label.value()->data(), label.value()->size());
 
-      if (EVP_PKEY_CTX_set0_rsa_oaep_label(ctx, label_copy, native_label->size()) <= 0) {
+      if (EVP_PKEY_CTX_set0_rsa_oaep_label(ctx, label_copy, label.value()->size()) <= 0) {
         OPENSSL_free(label_copy);
         EVP_PKEY_CTX_free(ctx);
         throw std::runtime_error("Failed to set OAEP label");
@@ -446,9 +439,8 @@ std::shared_ptr<ArrayBuffer> HybridRsaCipher::privateDecrypt(const std::shared_p
     }
   }
 
-  auto native_data = ToNativeArrayBuffer(data);
-  const unsigned char* in = native_data->data();
-  size_t inlen = native_data->size();
+  const unsigned char* in = data->data();
+  size_t inlen = data->size();
 
   // Both decrypt calls below operate on attacker-controlled ciphertext, so
   // any failure must be surfaced with an opaque, content-independent message.

--- a/packages/react-native-quick-crypto/cpp/cipher/OCBCipher.cpp
+++ b/packages/react-native-quick-crypto/cpp/cipher/OCBCipher.cpp
@@ -40,12 +40,11 @@ bool OCBCipher::setAuthTag(const std::shared_ptr<ArrayBuffer>& tag) {
   if (is_cipher) {
     throw std::runtime_error("setAuthTag can only be called during decryption.");
   }
-  auto native_tag = ToNativeArrayBuffer(tag);
-  size_t tag_len = native_tag->size();
+  size_t tag_len = tag->size();
   if (tag_len < 8 || tag_len > 16) {
     throw std::runtime_error("Invalid OCB tag length");
   }
-  if (EVP_CIPHER_CTX_ctrl(ctx.get(), EVP_CTRL_AEAD_SET_TAG, tag_len, native_tag->data()) != 1) {
+  if (EVP_CIPHER_CTX_ctrl(ctx.get(), EVP_CTRL_AEAD_SET_TAG, tag_len, tag->data()) != 1) {
     throw std::runtime_error("Failed to set OCB auth tag");
   }
   auth_tag_len = tag_len;

--- a/packages/react-native-quick-crypto/cpp/cipher/XChaCha20Poly1305Cipher.cpp
+++ b/packages/react-native-quick-crypto/cpp/cipher/XChaCha20Poly1305Cipher.cpp
@@ -29,19 +29,16 @@ XChaCha20Poly1305Cipher::~XChaCha20Poly1305Cipher() {
 }
 
 void XChaCha20Poly1305Cipher::init(const std::shared_ptr<ArrayBuffer> cipher_key, const std::shared_ptr<ArrayBuffer> iv) {
-  auto native_key = ToNativeArrayBuffer(cipher_key);
-  auto native_iv = ToNativeArrayBuffer(iv);
-
-  if (native_key->size() != kKeySize) {
-    throw std::runtime_error("XChaCha20-Poly1305 key must be 32 bytes, got " + std::to_string(native_key->size()) + " bytes");
+  if (cipher_key->size() != kKeySize) {
+    throw std::runtime_error("XChaCha20-Poly1305 key must be 32 bytes, got " + std::to_string(cipher_key->size()) + " bytes");
   }
 
-  if (native_iv->size() != kNonceSize) {
-    throw std::runtime_error("XChaCha20-Poly1305 nonce must be 24 bytes, got " + std::to_string(native_iv->size()) + " bytes");
+  if (iv->size() != kNonceSize) {
+    throw std::runtime_error("XChaCha20-Poly1305 nonce must be 24 bytes, got " + std::to_string(iv->size()) + " bytes");
   }
 
-  std::memcpy(key_, native_key->data(), kKeySize);
-  std::memcpy(nonce_, native_iv->data(), kNonceSize);
+  std::memcpy(key_, cipher_key->data(), kKeySize);
+  std::memcpy(nonce_, iv->data(), kNonceSize);
 
   data_buffer_.clear();
   aad_.clear();
@@ -53,12 +50,11 @@ std::shared_ptr<ArrayBuffer> XChaCha20Poly1305Cipher::update(const std::shared_p
 #ifndef BLSALLOC_SODIUM
   throw std::runtime_error("XChaCha20Poly1305Cipher: libsodium must be enabled (BLSALLOC_SODIUM)");
 #else
-  auto native_data = ToNativeArrayBuffer(data);
-  size_t data_len = native_data->size();
+  size_t data_len = data->size();
 
   size_t old_size = data_buffer_.size();
   data_buffer_.resize(old_size + data_len);
-  std::memcpy(data_buffer_.data() + old_size, native_data->data(), data_len);
+  std::memcpy(data_buffer_.data() + old_size, data->data(), data_len);
 
   return std::make_shared<NativeArrayBuffer>(nullptr, 0, nullptr);
 #endif
@@ -114,9 +110,8 @@ bool XChaCha20Poly1305Cipher::setAAD(const std::shared_ptr<ArrayBuffer>& data, s
 #ifndef BLSALLOC_SODIUM
   throw std::runtime_error("XChaCha20Poly1305Cipher: libsodium must be enabled (BLSALLOC_SODIUM)");
 #else
-  auto native_aad = ToNativeArrayBuffer(data);
-  aad_.resize(native_aad->size());
-  std::memcpy(aad_.data(), native_aad->data(), native_aad->size());
+  aad_.resize(data->size());
+  std::memcpy(aad_.data(), data->data(), data->size());
   return true;
 #endif
 }
@@ -147,12 +142,11 @@ bool XChaCha20Poly1305Cipher::setAuthTag(const std::shared_ptr<ArrayBuffer>& tag
     throw std::runtime_error("setAuthTag can only be called during decryption");
   }
 
-  auto native_tag = ToNativeArrayBuffer(tag);
-  if (native_tag->size() != kTagSize) {
-    throw std::runtime_error("XChaCha20-Poly1305 tag must be 16 bytes, got " + std::to_string(native_tag->size()) + " bytes");
+  if (tag->size() != kTagSize) {
+    throw std::runtime_error("XChaCha20-Poly1305 tag must be 16 bytes, got " + std::to_string(tag->size()) + " bytes");
   }
 
-  std::memcpy(auth_tag_, native_tag->data(), kTagSize);
+  std::memcpy(auth_tag_, tag->data(), kTagSize);
   return true;
 #endif
 }

--- a/packages/react-native-quick-crypto/cpp/cipher/XSalsa20Cipher.cpp
+++ b/packages/react-native-quick-crypto/cpp/cipher/XSalsa20Cipher.cpp
@@ -13,23 +13,20 @@ namespace margelo::nitro::crypto {
  * Initialize the cipher with a key and a nonce (using iv argument as nonce)
  */
 void XSalsa20Cipher::init(const std::shared_ptr<ArrayBuffer> cipher_key, const std::shared_ptr<ArrayBuffer> iv) {
-  auto native_key = ToNativeArrayBuffer(cipher_key);
-  auto native_iv = ToNativeArrayBuffer(iv);
-
   // Validate key size
-  if (native_key->size() < crypto_stream_KEYBYTES) {
+  if (cipher_key->size() < crypto_stream_KEYBYTES) {
     throw std::runtime_error("XSalsa20 key too short: expected " + std::to_string(crypto_stream_KEYBYTES) + " bytes, got " +
-                             std::to_string(native_key->size()) + " bytes.");
+                             std::to_string(cipher_key->size()) + " bytes.");
   }
   // Validate nonce size
-  if (native_iv->size() < crypto_stream_NONCEBYTES) {
+  if (iv->size() < crypto_stream_NONCEBYTES) {
     throw std::runtime_error("XSalsa20 nonce too short: expected " + std::to_string(crypto_stream_NONCEBYTES) + " bytes, got " +
-                             std::to_string(native_iv->size()) + " bytes.");
+                             std::to_string(iv->size()) + " bytes.");
   }
 
   // Copy key and nonce data
-  std::memcpy(key, native_key->data(), crypto_stream_KEYBYTES);
-  std::memcpy(nonce, native_iv->data(), crypto_stream_NONCEBYTES);
+  std::memcpy(key, cipher_key->data(), crypto_stream_KEYBYTES);
+  std::memcpy(nonce, iv->data(), crypto_stream_NONCEBYTES);
 
   // Reset streaming state so a re-init'd cipher does not accidentally reuse
   // keystream bytes from a previous session.
@@ -57,8 +54,7 @@ std::shared_ptr<ArrayBuffer> XSalsa20Cipher::update(const std::shared_ptr<ArrayB
 #ifndef BLSALLOC_SODIUM
   throw std::runtime_error("XSalsa20Cipher: libsodium must be enabled to use this cipher (BLSALLOC_SODIUM is not defined).");
 #else
-  auto native_data = ToNativeArrayBuffer(data);
-  const std::size_t data_size = native_data->size();
+  const std::size_t data_size = data->size();
 
   if (data_size == 0) {
     return std::make_shared<NativeArrayBuffer>(nullptr, 0, nullptr);
@@ -66,7 +62,7 @@ std::shared_ptr<ArrayBuffer> XSalsa20Cipher::update(const std::shared_ptr<ArrayB
 
   // Owning buffer: prevents leaking `output` if we throw on the way out.
   auto output = std::make_unique<uint8_t[]>(data_size);
-  const uint8_t* input = native_data->data();
+  const uint8_t* input = data->data();
   std::size_t pos = 0;
 
   // (1) Drain any unused keystream from the previous update()'s tail block.

--- a/packages/react-native-quick-crypto/cpp/cipher/XSalsa20Poly1305Cipher.cpp
+++ b/packages/react-native-quick-crypto/cpp/cipher/XSalsa20Poly1305Cipher.cpp
@@ -20,19 +20,16 @@ XSalsa20Poly1305Cipher::~XSalsa20Poly1305Cipher() {
 }
 
 void XSalsa20Poly1305Cipher::init(const std::shared_ptr<ArrayBuffer> cipher_key, const std::shared_ptr<ArrayBuffer> iv) {
-  auto native_key = ToNativeArrayBuffer(cipher_key);
-  auto native_iv = ToNativeArrayBuffer(iv);
-
-  if (native_key->size() != kKeySize) {
-    throw std::runtime_error("XSalsa20-Poly1305 key must be 32 bytes, got " + std::to_string(native_key->size()) + " bytes");
+  if (cipher_key->size() != kKeySize) {
+    throw std::runtime_error("XSalsa20-Poly1305 key must be 32 bytes, got " + std::to_string(cipher_key->size()) + " bytes");
   }
 
-  if (native_iv->size() != kNonceSize) {
-    throw std::runtime_error("XSalsa20-Poly1305 nonce must be 24 bytes, got " + std::to_string(native_iv->size()) + " bytes");
+  if (iv->size() != kNonceSize) {
+    throw std::runtime_error("XSalsa20-Poly1305 nonce must be 24 bytes, got " + std::to_string(iv->size()) + " bytes");
   }
 
-  std::memcpy(key_, native_key->data(), kKeySize);
-  std::memcpy(nonce_, native_iv->data(), kNonceSize);
+  std::memcpy(key_, cipher_key->data(), kKeySize);
+  std::memcpy(nonce_, iv->data(), kNonceSize);
 
   data_buffer_.clear();
   is_finalized = false;
@@ -43,12 +40,11 @@ std::shared_ptr<ArrayBuffer> XSalsa20Poly1305Cipher::update(const std::shared_pt
 #ifndef BLSALLOC_SODIUM
   throw std::runtime_error("XSalsa20Poly1305Cipher: libsodium must be enabled (BLSALLOC_SODIUM)");
 #else
-  auto native_data = ToNativeArrayBuffer(data);
-  size_t data_len = native_data->size();
+  size_t data_len = data->size();
 
   size_t old_size = data_buffer_.size();
   data_buffer_.resize(old_size + data_len);
-  std::memcpy(data_buffer_.data() + old_size, native_data->data(), data_len);
+  std::memcpy(data_buffer_.data() + old_size, data->data(), data_len);
 
   return std::make_shared<NativeArrayBuffer>(nullptr, 0, nullptr);
 #endif
@@ -126,12 +122,11 @@ bool XSalsa20Poly1305Cipher::setAuthTag(const std::shared_ptr<ArrayBuffer>& tag)
     throw std::runtime_error("setAuthTag can only be called during decryption");
   }
 
-  auto native_tag = ToNativeArrayBuffer(tag);
-  if (native_tag->size() != kTagSize) {
-    throw std::runtime_error("XSalsa20-Poly1305 tag must be 16 bytes, got " + std::to_string(native_tag->size()) + " bytes");
+  if (tag->size() != kTagSize) {
+    throw std::runtime_error("XSalsa20-Poly1305 tag must be 16 bytes, got " + std::to_string(tag->size()) + " bytes");
   }
 
-  std::memcpy(auth_tag_, native_tag->data(), kTagSize);
+  std::memcpy(auth_tag_, tag->data(), kTagSize);
   return true;
 #endif
 }

--- a/packages/react-native-quick-crypto/cpp/sign/HybridSignHandle.cpp
+++ b/packages/react-native-quick-crypto/cpp/sign/HybridSignHandle.cpp
@@ -58,15 +58,13 @@ void HybridSignHandle::update(const std::shared_ptr<ArrayBuffer>& data) {
     throw std::runtime_error("Sign not initialized");
   }
 
-  auto native_data = ToNativeArrayBuffer(data);
-
   // Accumulate raw data for potential one-shot signing (Ed25519/Ed448/ML-DSA)
-  const uint8_t* ptr = reinterpret_cast<const uint8_t*>(native_data->data());
-  data_buffer.insert(data_buffer.end(), ptr, ptr + native_data->size());
+  const uint8_t* ptr = reinterpret_cast<const uint8_t*>(data->data());
+  data_buffer.insert(data_buffer.end(), ptr, ptr + data->size());
 
   // Only update digest if we have one (not needed for pure signature schemes)
   if (md != nullptr) {
-    if (EVP_DigestUpdate(md_ctx, native_data->data(), native_data->size()) <= 0) {
+    if (EVP_DigestUpdate(md_ctx, data->data(), data->size()) <= 0) {
       unsigned long err = ERR_get_error();
       char err_buf[256];
       ERR_error_string_n(err, err_buf, sizeof(err_buf));

--- a/packages/react-native-quick-crypto/cpp/sign/HybridVerifyHandle.cpp
+++ b/packages/react-native-quick-crypto/cpp/sign/HybridVerifyHandle.cpp
@@ -58,15 +58,13 @@ void HybridVerifyHandle::update(const std::shared_ptr<ArrayBuffer>& data) {
     throw std::runtime_error("Verify not initialized");
   }
 
-  auto native_data = ToNativeArrayBuffer(data);
-
   // Accumulate raw data for potential one-shot verification (Ed25519/Ed448/ML-DSA)
-  const uint8_t* ptr = reinterpret_cast<const uint8_t*>(native_data->data());
-  data_buffer.insert(data_buffer.end(), ptr, ptr + native_data->size());
+  const uint8_t* ptr = reinterpret_cast<const uint8_t*>(data->data());
+  data_buffer.insert(data_buffer.end(), ptr, ptr + data->size());
 
   // Only update digest if we have one (not needed for pure signature schemes)
   if (md != nullptr) {
-    if (EVP_DigestUpdate(md_ctx, native_data->data(), native_data->size()) <= 0) {
+    if (EVP_DigestUpdate(md_ctx, data->data(), data->size()) <= 0) {
       unsigned long err = ERR_get_error();
       char err_buf[256];
       ERR_error_string_n(err, err_buf, sizeof(err_buf));
@@ -107,9 +105,8 @@ bool HybridVerifyHandle::verify(const std::shared_ptr<HybridKeyObjectHandleSpec>
     throw std::runtime_error("Invalid public key for verification");
   }
 
-  auto native_sig = ToNativeArrayBuffer(signature);
-  const unsigned char* sig_data = native_sig->data();
-  size_t sig_len = native_sig->size();
+  const unsigned char* sig_data = signature->data();
+  size_t sig_len = signature->size();
 
   // Ed25519/Ed448/ML-DSA require one-shot verification with EVP_DigestVerify
   // Also use one-shot path if no digest was specified (md == nullptr)


### PR DESCRIPTION
This PR reduces unnecessary data copying from `ToNativeArrayBuffer()`
As [documented](https://nitro.margelo.com/docs/types/array-buffers#non-owning), it's safe to use the non-owning `ArrayBuffer` before the sync function returns. I checked such cases and removed `ToNativeArrayBuffer()` in them.