### PR TITLE
feat: PQC JWK import/export for ML-DSA and ML-KEM

### DIFF
--- a/docs/content/docs/api/pqc.mdx
+++ b/docs/content/docs/api/pqc.mdx
@@ -203,7 +203,7 @@ const recoveredKey = await subtle.decapsulateKey(
 | Algorithm | `spki` | `pkcs8` | `jwk` | `raw-public` | `raw-seed` |
 |:----------|:------:|:-------:|:-----:|:------------:|:----------:|
 | ML-DSA-44/65/87 | ✅ | ✅ | ✅ | ✅ | ✅ |
-| ML-KEM-512/768/1024 | ✅ | ✅ | | ✅ | ✅ |
+| ML-KEM-512/768/1024 | ✅ | ✅ | ✅ | ✅ | ✅ |
 
 ```ts
 // Export ML-DSA public key as JWK

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2815,7 +2815,7 @@ SPEC CHECKSUMS:
   NitroMmkv: afbc5b2fbf963be567c6c545aa1efcf6a9cec68e
   NitroModules: 11bba9d065af151eae51e38a6425e04c3b223ff3
   OpenSSL-Universal: 9110d21982bb7e8b22a962b6db56a8aa805afde7
-  QuickCrypto: 962a3395bab0cacced1815b6cc0fa177515aff9f
+  QuickCrypto: 30f0d4eceadf1dbb9df5c17605e9f4279a0041ea
   RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
   RCTDeprecation: c4b9e2fd0ab200e3af72b013ed6113187c607077
   RCTRequired: e97dd5dafc1db8094e63bc5031e0371f092ae92a

--- a/example/package.json
+++ b/example/package.json
@@ -40,7 +40,7 @@
     "react-native-mmkv": "4.0.1",
     "react-native-nitro-modules": "0.33.2",
     "react-native-quick-base64": "2.2.2",
-    "react-native-quick-crypto": "1.1.1",
+    "react-native-quick-crypto": "workspace:*",
     "react-native-safe-area-context": "5.6.2",
     "react-native-screens": "4.18.0",
     "react-native-vector-icons": "10.3.0",

--- a/example/src/tests/subtle/import_export.ts
+++ b/example/src/tests/subtle/import_export.ts
@@ -2246,8 +2246,8 @@ for (const variant of MLDSA_VARIANTS) {
   });
 }
 
-// ML-DSA error handling tests
-test(SUITE, 'ML-DSA-44 importKey rejects jwk format', async () => {
+// ML-DSA JWK error handling tests
+test(SUITE, 'ML-DSA-44 importKey rejects wrong jwk kty', async () => {
   await assertThrowsAsync(
     async () =>
       await subtle.importKey(
@@ -2255,9 +2255,31 @@ test(SUITE, 'ML-DSA-44 importKey rejects jwk format', async () => {
         { kty: 'OKP', alg: 'ML-DSA-44' },
         { name: 'ML-DSA-44' },
         true,
-        ['sign'],
+        ['verify'],
       ),
-    'NotSupportedError',
+    'DataError',
+  );
+});
+
+test(SUITE, 'ML-DSA-44 importKey rejects jwk alg mismatch', async () => {
+  const keyPair = (await subtle.generateKey({ name: 'ML-DSA-44' }, true, [
+    'sign',
+    'verify',
+  ])) as CryptoKeyPair;
+  const jwk = (await subtle.exportKey(
+    'jwk',
+    keyPair.publicKey as CryptoKey,
+  )) as JWK;
+  await assertThrowsAsync(
+    async () =>
+      await subtle.importKey(
+        'jwk',
+        { ...jwk, alg: 'ML-DSA-65' },
+        { name: 'ML-DSA-44' },
+        true,
+        ['verify'],
+      ),
+    'DataError',
   );
 });
 
@@ -2386,6 +2408,116 @@ for (const variant of MLDSA_VARIANTS) {
   );
 }
 
+// --- ML-DSA JWK import/export round-trip tests ---
+
+for (const variant of MLDSA_VARIANTS) {
+  test(SUITE, `${variant} jwk export public key`, async () => {
+    const keyPair = (await subtle.generateKey({ name: variant }, true, [
+      'sign',
+      'verify',
+    ])) as CryptoKeyPair;
+
+    const jwk = (await subtle.exportKey(
+      'jwk',
+      keyPair.publicKey as CryptoKey,
+    )) as JWK;
+
+    expect(jwk.kty).to.equal('AKP');
+    expect(jwk.alg).to.equal(variant);
+    expect(jwk.pub).to.be.a('string');
+    expect(jwk.priv).to.equal(undefined);
+    expect(jwk.key_ops).to.deep.equal(['verify']);
+    expect(jwk.ext).to.equal(true);
+  });
+
+  test(SUITE, `${variant} jwk export private key`, async () => {
+    const keyPair = (await subtle.generateKey({ name: variant }, true, [
+      'sign',
+      'verify',
+    ])) as CryptoKeyPair;
+
+    const jwk = (await subtle.exportKey(
+      'jwk',
+      keyPair.privateKey as CryptoKey,
+    )) as JWK;
+
+    expect(jwk.kty).to.equal('AKP');
+    expect(jwk.alg).to.equal(variant);
+    expect(jwk.pub).to.be.a('string');
+    expect(jwk.priv).to.be.a('string');
+    expect(jwk.key_ops).to.deep.equal(['sign']);
+    expect(jwk.ext).to.equal(true);
+  });
+
+  test(SUITE, `${variant} jwk public key round-trip + verify`, async () => {
+    const keyPair = (await subtle.generateKey({ name: variant }, true, [
+      'sign',
+      'verify',
+    ])) as CryptoKeyPair;
+
+    const jwk = (await subtle.exportKey(
+      'jwk',
+      keyPair.publicKey as CryptoKey,
+    )) as JWK;
+
+    const imported = await subtle.importKey(
+      'jwk',
+      jwk,
+      { name: variant },
+      true,
+      ['verify'],
+    );
+    expect(imported.type).to.equal('public');
+    expect(imported.algorithm.name).to.equal(variant);
+
+    const testData = new TextEncoder().encode('ML-DSA JWK round-trip');
+    const signature = await subtle.sign(
+      { name: variant },
+      keyPair.privateKey as CryptoKey,
+      testData,
+    );
+    const isValid = await subtle.verify(
+      { name: variant },
+      imported,
+      signature,
+      testData,
+    );
+    expect(isValid).to.equal(true);
+  });
+
+  test(SUITE, `${variant} jwk private key round-trip + sign`, async () => {
+    const keyPair = (await subtle.generateKey({ name: variant }, true, [
+      'sign',
+      'verify',
+    ])) as CryptoKeyPair;
+
+    const jwk = (await subtle.exportKey(
+      'jwk',
+      keyPair.privateKey as CryptoKey,
+    )) as JWK;
+
+    const imported = await subtle.importKey(
+      'jwk',
+      jwk,
+      { name: variant },
+      true,
+      ['sign'],
+    );
+    expect(imported.type).to.equal('private');
+    expect(imported.algorithm.name).to.equal(variant);
+
+    const testData = new TextEncoder().encode('ML-DSA JWK private round-trip');
+    const signature = await subtle.sign({ name: variant }, imported, testData);
+    const isValid = await subtle.verify(
+      { name: variant },
+      keyPair.publicKey as CryptoKey,
+      signature,
+      testData,
+    );
+    expect(isValid).to.equal(true);
+  });
+}
+
 // --- ML-KEM Import/Export Tests ---
 
 for (const variant of MLKEM_VARIANTS) {
@@ -2432,6 +2564,110 @@ for (const variant of MLKEM_VARIANTS) {
     expect(imported.type).to.equal('private');
     expect(imported.algorithm.name).to.equal(variant);
   });
+}
+
+// --- ML-KEM JWK import/export round-trip tests ---
+
+for (const variant of MLKEM_VARIANTS) {
+  test(SUITE, `${variant} jwk export public key`, async () => {
+    const keyPair = (await subtle.generateKey({ name: variant }, true, [
+      'encapsulateBits',
+      'decapsulateBits',
+    ])) as CryptoKeyPair;
+
+    const jwk = (await subtle.exportKey(
+      'jwk',
+      keyPair.publicKey as CryptoKey,
+    )) as JWK;
+
+    expect(jwk.kty).to.equal('AKP');
+    expect(jwk.alg).to.equal(variant);
+    expect(jwk.pub).to.be.a('string');
+    expect(jwk.priv).to.equal(undefined);
+    expect(jwk.key_ops).to.deep.equal(['encapsulateBits']);
+    expect(jwk.ext).to.equal(true);
+  });
+
+  test(SUITE, `${variant} jwk export private key`, async () => {
+    const keyPair = (await subtle.generateKey({ name: variant }, true, [
+      'encapsulateBits',
+      'decapsulateBits',
+    ])) as CryptoKeyPair;
+
+    const jwk = (await subtle.exportKey(
+      'jwk',
+      keyPair.privateKey as CryptoKey,
+    )) as JWK;
+
+    expect(jwk.kty).to.equal('AKP');
+    expect(jwk.alg).to.equal(variant);
+    expect(jwk.pub).to.be.a('string');
+    expect(jwk.priv).to.be.a('string');
+    expect(jwk.key_ops).to.deep.equal(['decapsulateBits']);
+    expect(jwk.ext).to.equal(true);
+  });
+
+  test(SUITE, `${variant} jwk public key round-trip`, async () => {
+    const keyPair = (await subtle.generateKey({ name: variant }, true, [
+      'encapsulateBits',
+      'decapsulateBits',
+    ])) as CryptoKeyPair;
+
+    const jwk = (await subtle.exportKey(
+      'jwk',
+      keyPair.publicKey as CryptoKey,
+    )) as JWK;
+
+    const imported = await subtle.importKey(
+      'jwk',
+      jwk,
+      { name: variant },
+      true,
+      ['encapsulateBits'],
+    );
+    expect(imported.type).to.equal('public');
+    expect(imported.algorithm.name).to.equal(variant);
+  });
+
+  test(
+    SUITE,
+    `${variant} jwk private key round-trip + decapsulate`,
+    async () => {
+      const keyPair = (await subtle.generateKey({ name: variant }, true, [
+        'encapsulateBits',
+        'decapsulateBits',
+      ])) as CryptoKeyPair;
+
+      const jwk = (await subtle.exportKey(
+        'jwk',
+        keyPair.privateKey as CryptoKey,
+      )) as JWK;
+
+      const imported = await subtle.importKey(
+        'jwk',
+        jwk,
+        { name: variant },
+        true,
+        ['decapsulateBits'],
+      );
+      expect(imported.type).to.equal('private');
+      expect(imported.algorithm.name).to.equal(variant);
+
+      // Encapsulate with original public key, decapsulate with imported private key
+      const { sharedKey, ciphertext } = await subtle.encapsulateBits(
+        { name: variant },
+        keyPair.publicKey as CryptoKey,
+      );
+      const recovered = await subtle.decapsulateBits(
+        { name: variant },
+        imported,
+        ciphertext,
+      );
+      expect(new Uint8Array(recovered)).to.deep.equal(
+        new Uint8Array(sharedKey),
+      );
+    },
+  );
 }
 
 test(SUITE, 'ML-KEM-768 importKey raw rejects bad usages', async () => {

--- a/packages/react-native-quick-crypto/cpp/keys/HybridKeyObjectHandle.cpp
+++ b/packages/react-native-quick-crypto/cpp/keys/HybridKeyObjectHandle.cpp
@@ -364,6 +364,37 @@ JWK HybridKeyObjectHandle::exportJwk(const JWK& key, bool handleRsaPss) {
     return result;
   }
 
+#if OPENSSL_VERSION_NUMBER >= 0x30500000L
+  // Export AKP keys (ML-DSA, ML-KEM) per draft-ietf-cose-dilithium and RFC 9269
+  {
+    const char* typeName = EVP_PKEY_get0_type_name(pkey.get());
+    if (typeName != nullptr) {
+      std::string name(typeName);
+      bool isPqcKey = (name.starts_with("ML-DSA-") || name.starts_with("ML-KEM-"));
+      if (isPqcKey) {
+        result.kty = JWKkty::AKP;
+        result.alg = name;
+
+        auto pubKey = pkey.rawPublicKey();
+        if (!pubKey) {
+          throw std::runtime_error("Failed to get raw public key for AKP JWK export");
+        }
+        result.pub = base64url_encode(reinterpret_cast<const unsigned char*>(pubKey.get()), pubKey.size());
+
+        if (keyType == KeyType::PRIVATE) {
+          auto seed = pkey.rawSeed();
+          if (!seed) {
+            throw std::runtime_error("Key does not have an available seed");
+          }
+          result.priv = base64url_encode(reinterpret_cast<const unsigned char*>(seed.get()), seed.size());
+        }
+
+        return result;
+      }
+    }
+  }
+#endif
+
   throw std::runtime_error("Unsupported key type for JWK export");
 }
 
@@ -702,6 +733,72 @@ std::optional<KeyType> HybridKeyObjectHandle::initJwk(const JWK& keyData, std::o
       return KeyType::PUBLIC;
     }
   }
+
+#if OPENSSL_VERSION_NUMBER >= 0x30500000L
+  // Handle AKP keys (ML-DSA, ML-KEM)
+  if (kty == JWKkty::AKP) {
+    if (!keyData.alg.has_value()) {
+      throw std::runtime_error("JWK AKP key missing 'alg' field");
+    }
+    if (!keyData.pub.has_value()) {
+      throw std::runtime_error("JWK AKP key missing 'pub' field");
+    }
+
+    const std::string& alg = keyData.alg.value();
+    int nid = 0;
+    if (alg == "ML-DSA-44")
+      nid = EVP_PKEY_ML_DSA_44;
+    else if (alg == "ML-DSA-65")
+      nid = EVP_PKEY_ML_DSA_65;
+    else if (alg == "ML-DSA-87")
+      nid = EVP_PKEY_ML_DSA_87;
+    else if (alg == "ML-KEM-512")
+      nid = EVP_PKEY_ML_KEM_512;
+    else if (alg == "ML-KEM-768")
+      nid = EVP_PKEY_ML_KEM_768;
+    else if (alg == "ML-KEM-1024")
+      nid = EVP_PKEY_ML_KEM_1024;
+    else
+      throw std::runtime_error("Unsupported JWK AKP \"alg\": " + alg);
+
+    bool isPrivate = keyData.priv.has_value();
+    ncrypto::EVPKeyPointer pkey;
+
+    if (isPrivate) {
+      std::string seedBytes = base64url_decode(keyData.priv.value());
+      ncrypto::Buffer<const unsigned char> buf{
+          .data = reinterpret_cast<const unsigned char*>(seedBytes.data()),
+          .len = seedBytes.size(),
+      };
+      pkey = ncrypto::EVPKeyPointer::NewRawSeed(nid, buf);
+      if (!pkey) {
+        throw std::runtime_error("Invalid JWK AKP key");
+      }
+
+      // Verify the pub field matches the public key derived from the seed.
+      std::string pubBytes = base64url_decode(keyData.pub.value());
+      auto derivedPub = pkey.rawPublicKey();
+      if (!derivedPub || derivedPub.size() != pubBytes.size() || CRYPTO_memcmp(derivedPub.get(), pubBytes.data(), pubBytes.size()) != 0) {
+        throw std::runtime_error("Invalid JWK AKP key");
+      }
+
+      data_ = KeyObjectData::CreateAsymmetric(KeyType::PRIVATE, std::move(pkey));
+      return KeyType::PRIVATE;
+    } else {
+      std::string pubBytes = base64url_decode(keyData.pub.value());
+      ncrypto::Buffer<const unsigned char> buf{
+          .data = reinterpret_cast<const unsigned char*>(pubBytes.data()),
+          .len = pubBytes.size(),
+      };
+      pkey = ncrypto::EVPKeyPointer::NewRawPublic(nid, buf);
+      if (!pkey) {
+        throw std::runtime_error("Invalid JWK AKP key");
+      }
+      data_ = KeyObjectData::CreateAsymmetric(KeyType::PUBLIC, std::move(pkey));
+      return KeyType::PUBLIC;
+    }
+  }
+#endif
 
   throw std::runtime_error("Unsupported JWK key type");
 }

--- a/packages/react-native-quick-crypto/cpp/keys/HybridKeyObjectHandle.cpp
+++ b/packages/react-native-quick-crypto/cpp/keys/HybridKeyObjectHandle.cpp
@@ -365,7 +365,7 @@ JWK HybridKeyObjectHandle::exportJwk(const JWK& key, bool handleRsaPss) {
   }
 
 #if OPENSSL_VERSION_NUMBER >= 0x30500000L
-  // Export AKP keys (ML-DSA, ML-KEM) per draft-ietf-cose-dilithium and RFC 9269
+  // Export AKP keys (ML-DSA, ML-KEM)
   {
     const char* typeName = EVP_PKEY_get0_type_name(pkey.get());
     if (typeName != nullptr) {

--- a/packages/react-native-quick-crypto/nitrogen/generated/shared/c++/JWK.hpp
+++ b/packages/react-native-quick-crypto/nitrogen/generated/shared/c++/JWK.hpp
@@ -70,11 +70,13 @@ namespace margelo::nitro::crypto {
     std::optional<std::string> dp     SWIFT_PRIVATE;
     std::optional<std::string> dq     SWIFT_PRIVATE;
     std::optional<std::string> qi     SWIFT_PRIVATE;
+    std::optional<std::string> pub     SWIFT_PRIVATE;
+    std::optional<std::string> priv     SWIFT_PRIVATE;
     std::optional<bool> ext     SWIFT_PRIVATE;
 
   public:
     JWK() = default;
-    explicit JWK(std::optional<JWKkty> kty, std::optional<JWKuse> use, std::optional<std::vector<KeyUsage>> key_ops, std::optional<std::string> alg, std::optional<std::string> crv, std::optional<std::string> kid, std::optional<std::string> x5u, std::optional<std::vector<std::string>> x5c, std::optional<std::string> x5t, std::optional<std::string> x5t_256, std::optional<std::string> n, std::optional<std::string> e, std::optional<std::string> d, std::optional<std::string> p, std::optional<std::string> q, std::optional<std::string> x, std::optional<std::string> y, std::optional<std::string> k, std::optional<std::string> dp, std::optional<std::string> dq, std::optional<std::string> qi, std::optional<bool> ext): kty(kty), use(use), key_ops(key_ops), alg(alg), crv(crv), kid(kid), x5u(x5u), x5c(x5c), x5t(x5t), x5t_256(x5t_256), n(n), e(e), d(d), p(p), q(q), x(x), y(y), k(k), dp(dp), dq(dq), qi(qi), ext(ext) {}
+    explicit JWK(std::optional<JWKkty> kty, std::optional<JWKuse> use, std::optional<std::vector<KeyUsage>> key_ops, std::optional<std::string> alg, std::optional<std::string> crv, std::optional<std::string> kid, std::optional<std::string> x5u, std::optional<std::vector<std::string>> x5c, std::optional<std::string> x5t, std::optional<std::string> x5t_256, std::optional<std::string> n, std::optional<std::string> e, std::optional<std::string> d, std::optional<std::string> p, std::optional<std::string> q, std::optional<std::string> x, std::optional<std::string> y, std::optional<std::string> k, std::optional<std::string> dp, std::optional<std::string> dq, std::optional<std::string> qi, std::optional<std::string> pub, std::optional<std::string> priv, std::optional<bool> ext): kty(kty), use(use), key_ops(key_ops), alg(alg), crv(crv), kid(kid), x5u(x5u), x5c(x5c), x5t(x5t), x5t_256(x5t_256), n(n), e(e), d(d), p(p), q(q), x(x), y(y), k(k), dp(dp), dq(dq), qi(qi), pub(pub), priv(priv), ext(ext) {}
 
   public:
     friend bool operator==(const JWK& lhs, const JWK& rhs) = default;
@@ -111,6 +113,8 @@ namespace margelo::nitro {
         JSIConverter<std::optional<std::string>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "dp"))),
         JSIConverter<std::optional<std::string>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "dq"))),
         JSIConverter<std::optional<std::string>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "qi"))),
+        JSIConverter<std::optional<std::string>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "pub"))),
+        JSIConverter<std::optional<std::string>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "priv"))),
         JSIConverter<std::optional<bool>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "ext")))
       );
     }
@@ -137,6 +141,8 @@ namespace margelo::nitro {
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "dp"), JSIConverter<std::optional<std::string>>::toJSI(runtime, arg.dp));
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "dq"), JSIConverter<std::optional<std::string>>::toJSI(runtime, arg.dq));
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "qi"), JSIConverter<std::optional<std::string>>::toJSI(runtime, arg.qi));
+      obj.setProperty(runtime, PropNameIDCache::get(runtime, "pub"), JSIConverter<std::optional<std::string>>::toJSI(runtime, arg.pub));
+      obj.setProperty(runtime, PropNameIDCache::get(runtime, "priv"), JSIConverter<std::optional<std::string>>::toJSI(runtime, arg.priv));
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "ext"), JSIConverter<std::optional<bool>>::toJSI(runtime, arg.ext));
       return obj;
     }
@@ -169,6 +175,8 @@ namespace margelo::nitro {
       if (!JSIConverter<std::optional<std::string>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "dp")))) return false;
       if (!JSIConverter<std::optional<std::string>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "dq")))) return false;
       if (!JSIConverter<std::optional<std::string>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "qi")))) return false;
+      if (!JSIConverter<std::optional<std::string>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "pub")))) return false;
+      if (!JSIConverter<std::optional<std::string>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "priv")))) return false;
       if (!JSIConverter<std::optional<bool>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "ext")))) return false;
       return true;
     }

--- a/packages/react-native-quick-crypto/nitrogen/generated/shared/c++/JWKkty.hpp
+++ b/packages/react-native-quick-crypto/nitrogen/generated/shared/c++/JWKkty.hpp
@@ -34,6 +34,7 @@ namespace margelo::nitro::crypto {
     EC      SWIFT_NAME(ec) = 2,
     OCT      SWIFT_NAME(oct) = 3,
     OKP      SWIFT_NAME(okp) = 4,
+    AKP      SWIFT_NAME(akp) = 5,
   } CLOSED_ENUM;
 
 } // namespace margelo::nitro::crypto
@@ -51,6 +52,7 @@ namespace margelo::nitro {
         case hashString("EC"): return margelo::nitro::crypto::JWKkty::EC;
         case hashString("oct"): return margelo::nitro::crypto::JWKkty::OCT;
         case hashString("OKP"): return margelo::nitro::crypto::JWKkty::OKP;
+        case hashString("AKP"): return margelo::nitro::crypto::JWKkty::AKP;
         default: [[unlikely]]
           throw std::invalid_argument("Cannot convert \"" + unionValue + "\" to enum JWKkty - invalid value!");
       }
@@ -62,6 +64,7 @@ namespace margelo::nitro {
         case margelo::nitro::crypto::JWKkty::EC: return JSIConverter<std::string>::toJSI(runtime, "EC");
         case margelo::nitro::crypto::JWKkty::OCT: return JSIConverter<std::string>::toJSI(runtime, "oct");
         case margelo::nitro::crypto::JWKkty::OKP: return JSIConverter<std::string>::toJSI(runtime, "OKP");
+        case margelo::nitro::crypto::JWKkty::AKP: return JSIConverter<std::string>::toJSI(runtime, "AKP");
         default: [[unlikely]]
           throw std::invalid_argument("Cannot convert JWKkty to JS - invalid value: "
                                     + std::to_string(static_cast<int>(arg)) + "!");
@@ -78,6 +81,7 @@ namespace margelo::nitro {
         case hashString("EC"):
         case hashString("oct"):
         case hashString("OKP"):
+        case hashString("AKP"):
           return true;
         default:
           return false;

--- a/packages/react-native-quick-crypto/package.json
+++ b/packages/react-native-quick-crypto/package.json
@@ -164,8 +164,7 @@
           {
             "file": "../../example/package.json",
             "path": [
-              "version",
-              "dependencies.react-native-quick-crypto"
+              "version"
             ]
           }
         ]

--- a/packages/react-native-quick-crypto/src/ec.ts
+++ b/packages/react-native-quick-crypto/src/ec.ts
@@ -27,6 +27,7 @@ import {
   kNamedCurveAliases,
   lazyDOMException,
   normalizeHashName,
+  validateJwkStructure,
   HashContext,
   KeyEncoding,
   KFormatType,
@@ -93,36 +94,27 @@ export function ecImportKey(
     throw lazyDOMException('Unrecognized namedCurve', 'NotSupportedError');
   }
 
-  // Handle JWK format
   if (format === 'jwk') {
     const jwk = keyData as JWK;
 
-    // Validate JWK
+    if (!jwk || typeof jwk !== 'object') {
+      throw lazyDOMException('Invalid keyData', 'DataError');
+    }
     if (jwk.kty !== 'EC') {
       throw lazyDOMException('Invalid JWK "kty" Parameter', 'DataError');
     }
-
     if (jwk.crv !== namedCurve) {
       throw lazyDOMException(
         'JWK "crv" does not match the requested algorithm',
         'DataError',
       );
     }
+    const expectedUse = name === 'ECDH' ? 'enc' : 'sig';
+    validateJwkStructure(jwk, extractable, keyUsages, expectedUse);
 
-    // Check use parameter if present
-    if (jwk.use !== undefined) {
-      const expectedUse = name === 'ECDH' ? 'enc' : 'sig';
-      if (jwk.use !== expectedUse) {
-        throw lazyDOMException('Invalid JWK "use" Parameter', 'DataError');
-      }
-    }
-
-    // Check alg parameter if present
     if (jwk.alg !== undefined) {
       let expectedAlg: string | undefined;
-
       if (name === 'ECDSA') {
-        // Map namedCurve to expected ECDSA algorithm
         expectedAlg =
           namedCurve === 'P-256'
             ? 'ES256'
@@ -132,11 +124,9 @@ export function ecImportKey(
                 ? 'ES512'
                 : undefined;
       } else if (name === 'ECDH') {
-        // ECDH uses ECDH-ES algorithm
         expectedAlg = 'ECDH-ES';
       }
-
-      if (expectedAlg && jwk.alg !== undefined && jwk.alg !== expectedAlg) {
+      if (expectedAlg && jwk.alg !== expectedAlg) {
         throw lazyDOMException(
           'JWK "alg" does not match the requested algorithm',
           'DataError',
@@ -144,32 +134,49 @@ export function ecImportKey(
       }
     }
 
-    // Import using C++ layer
-    const handle =
-      NitroModules.createHybridObject<KeyObjectHandle>('KeyObjectHandle');
-    const keyType = handle.initJwk(jwk, namedCurve as NamedCurve);
-
-    if (keyType === undefined) {
-      throw lazyDOMException('Invalid JWK', 'DataError');
+    const isPublicJwk = jwk.d === undefined;
+    const validUsagesJwk: KeyUsage[] =
+      name === 'ECDSA'
+        ? isPublicJwk
+          ? ['verify']
+          : ['sign']
+        : isPublicJwk
+          ? []
+          : ['deriveKey', 'deriveBits'];
+    if (hasAnyNotIn(keyUsages, validUsagesJwk)) {
+      throw lazyDOMException(
+        `Unsupported key usage for a ${name} key`,
+        'SyntaxError',
+      );
     }
 
-    // Create the appropriate KeyObject based on type
+    const handle =
+      NitroModules.createHybridObject<KeyObjectHandle>('KeyObjectHandle');
+    let keyType: number | undefined;
+    try {
+      keyType = handle.initJwk(jwk, namedCurve as NamedCurve);
+    } catch (err) {
+      throw lazyDOMException('Invalid keyData', {
+        name: 'DataError',
+        cause: err,
+      });
+    }
+    if (keyType === undefined) {
+      throw lazyDOMException('Invalid keyData', 'DataError');
+    }
+
     let keyObject: KeyObject;
     if (keyType === 1) {
       keyObject = new PublicKeyObject(handle);
     } else if (keyType === 2) {
       keyObject = new PrivateKeyObject(handle);
     } else {
-      throw lazyDOMException(
-        'Unexpected key type from JWK import',
-        'DataError',
-      );
+      throw lazyDOMException('Invalid keyData', 'DataError');
     }
 
     return new CryptoKey(keyObject, algorithm, keyUsages, extractable);
   }
 
-  // Handle binary formats (spki, pkcs8, raw)
   if (format !== 'spki' && format !== 'pkcs8' && format !== 'raw') {
     throw lazyDOMException(
       `Unsupported format: ${format}`,
@@ -177,11 +184,9 @@ export function ecImportKey(
     );
   }
 
-  // Determine expected key type based on format
   const expectedKeyType =
     format === 'spki' || format === 'raw' ? 'public' : 'private';
 
-  // Validate usages for the key type
   const isPublicKey = expectedKeyType === 'public';
   let validUsages: KeyUsage[];
 

--- a/packages/react-native-quick-crypto/src/subtle.ts
+++ b/packages/react-native-quick-crypto/src/subtle.ts
@@ -31,7 +31,10 @@ import { bufferLikeToArrayBuffer } from './utils/conversion';
 import { argon2Sync } from './argon2';
 import { lazyDOMException } from './utils/errors';
 import { normalizeHashName, HashContext } from './utils/hashnames';
-import { validateMaxBufferLength } from './utils/validation';
+import {
+  validateJwkStructure,
+  validateMaxBufferLength,
+} from './utils/validation';
 import { asyncDigest } from './hash';
 import { createSecretKey, createPublicKey } from './keys';
 import { NitroModules } from 'react-native-nitro-modules';
@@ -122,37 +125,6 @@ function normalizeAlgorithm(
     return { ...algorithm, name: canonical };
   }
   return algorithm as SubtleAlgorithm;
-}
-
-// WebCrypto §25.7.6 (JWK import): if the JWK's `ext` member is present and
-// false, the requested `extractable` parameter must also be false. If the
-// JWK's `key_ops` member is present, every requested usage must appear in
-// it. We centralize the check here so every importKey path that accepts
-// `format === 'jwk'` can reuse it.
-function validateJwkExtAndKeyOps(
-  jwk: JWK,
-  extractable: boolean,
-  keyUsages: KeyUsage[],
-): void {
-  if (jwk.ext === false && extractable) {
-    throw lazyDOMException(
-      'JWK "ext" is false but extractable was requested',
-      'DataError',
-    );
-  }
-  if (jwk.key_ops !== undefined) {
-    if (!Array.isArray(jwk.key_ops)) {
-      throw lazyDOMException('JWK "key_ops" must be an array', 'DataError');
-    }
-    for (const usage of keyUsages) {
-      if (!jwk.key_ops.includes(usage)) {
-        throw lazyDOMException(
-          `JWK "key_ops" does not include requested usage "${usage}"`,
-          'DataError',
-        );
-      }
-    }
-  }
 }
 
 function getAlgorithmName(name: string, length: number): string {
@@ -862,13 +834,6 @@ async function kmacImportKey(
 ): Promise<CryptoKey> {
   const { name } = algorithm;
 
-  if (hasAnyNotIn(keyUsages, ['sign', 'verify'])) {
-    throw lazyDOMException(
-      `Unsupported key usage for ${name} key`,
-      'SyntaxError',
-    );
-  }
-
   let keyObject: KeyObject;
 
   if (format === 'jwk') {
@@ -877,31 +842,49 @@ async function kmacImportKey(
     if (!jwk || typeof jwk !== 'object') {
       throw lazyDOMException('Invalid keyData', 'DataError');
     }
-
-    validateJwkExtAndKeyOps(jwk, extractable, keyUsages);
-
     if (jwk.kty !== 'oct') {
-      throw lazyDOMException('Invalid JWK format for KMAC key', 'DataError');
+      throw lazyDOMException('Invalid JWK "kty" Parameter', 'DataError');
     }
+    validateJwkStructure(jwk, extractable, keyUsages, 'sig');
 
     const expectedAlg = name === 'KMAC128' ? 'K128' : 'K256';
     if (jwk.alg !== undefined && jwk.alg !== expectedAlg) {
       throw lazyDOMException(
-        'JWK "alg" does not match the requested algorithm',
+        'JWK "alg" Parameter and algorithm name mismatch',
         'DataError',
+      );
+    }
+
+    if (hasAnyNotIn(keyUsages, ['sign', 'verify'])) {
+      throw lazyDOMException(
+        `Unsupported key usage for ${name} key`,
+        'SyntaxError',
       );
     }
 
     const handle =
       NitroModules.createHybridObject<KeyObjectHandle>('KeyObjectHandle');
-    const keyType = handle.initJwk(jwk, undefined);
-
+    let keyType: KeyType | undefined;
+    try {
+      keyType = handle.initJwk(jwk, undefined);
+    } catch (err) {
+      throw lazyDOMException('Invalid keyData', {
+        name: 'DataError',
+        cause: err,
+      });
+    }
     if (keyType === undefined || keyType !== 0) {
-      throw lazyDOMException('Failed to import KMAC JWK', 'DataError');
+      throw lazyDOMException('Invalid keyData', 'DataError');
     }
 
     keyObject = new SecretKeyObject(handle);
   } else if (format === 'raw' || format === 'raw-secret') {
+    if (hasAnyNotIn(keyUsages, ['sign', 'verify'])) {
+      throw lazyDOMException(
+        `Unsupported key usage for ${name} key`,
+        'SyntaxError',
+      );
+    }
     keyObject = createSecretKey(data as BinaryLike);
   } else {
     throw lazyDOMException(
@@ -938,7 +921,6 @@ function rsaImportKey(
 ): CryptoKey {
   const { name } = algorithm;
 
-  // Validate usages
   let checkSet: KeyUsage[];
   switch (name) {
     case 'RSASSA-PKCS1-v1_5':
@@ -951,40 +933,54 @@ function rsaImportKey(
     default:
       throw new Error(`Unsupported RSA algorithm: ${name}`);
   }
-
-  if (hasAnyNotIn(keyUsages, checkSet)) {
-    throw new Error(`Unsupported key usage for ${name}`);
-  }
+  const checkUsages = (): void => {
+    if (hasAnyNotIn(keyUsages, checkSet)) {
+      throw lazyDOMException(
+        `Unsupported key usage for ${name} key`,
+        'SyntaxError',
+      );
+    }
+  };
 
   let keyObject: KeyObject;
 
   if (format === 'jwk') {
     const jwk = data as JWK;
 
-    // Validate JWK
-    if (jwk.kty !== 'RSA') {
-      throw new Error('Invalid JWK format for RSA key');
+    if (!jwk || typeof jwk !== 'object') {
+      throw lazyDOMException('Invalid keyData', 'DataError');
     }
-
-    validateJwkExtAndKeyOps(jwk, extractable, keyUsages);
+    if (jwk.kty !== 'RSA') {
+      throw lazyDOMException('Invalid JWK "kty" Parameter', 'DataError');
+    }
+    const expectedUse = name === 'RSA-OAEP' ? 'enc' : 'sig';
+    validateJwkStructure(jwk, extractable, keyUsages, expectedUse);
+    checkUsages();
 
     const handle =
       NitroModules.createHybridObject<KeyObjectHandle>('KeyObjectHandle');
-    const keyType = handle.initJwk(jwk, undefined);
-
+    let keyType: KeyType | undefined;
+    try {
+      keyType = handle.initJwk(jwk, undefined);
+    } catch (err) {
+      throw lazyDOMException('Invalid keyData', {
+        name: 'DataError',
+        cause: err,
+      });
+    }
     if (keyType === undefined) {
-      throw new Error('Failed to import RSA JWK');
+      throw lazyDOMException('Invalid keyData', 'DataError');
     }
 
-    // Create the appropriate KeyObject based on type
-    if (keyType === 1) {
+    if (keyType === KeyType.PUBLIC) {
       keyObject = new PublicKeyObject(handle);
-    } else if (keyType === 2) {
+    } else if (keyType === KeyType.PRIVATE) {
       keyObject = new PrivateKeyObject(handle);
     } else {
-      throw new Error('Unexpected key type from RSA JWK import');
+      throw lazyDOMException('Invalid keyData', 'DataError');
     }
   } else if (format === 'spki') {
+    checkUsages();
     const keyData = bufferLikeToArrayBuffer(data as BufferLike);
     keyObject = KeyObject.createKeyObject(
       'public',
@@ -993,6 +989,7 @@ function rsaImportKey(
       KeyEncoding.SPKI,
     );
   } else if (format === 'pkcs8') {
+    checkUsages();
     const keyData = bufferLikeToArrayBuffer(data as BufferLike);
     keyObject = KeyObject.createKeyObject(
       'private',
@@ -1001,7 +998,10 @@ function rsaImportKey(
       KeyEncoding.PKCS8,
     );
   } else {
-    throw new Error(`Unsupported format for RSA import: ${format}`);
+    throw lazyDOMException(
+      `Unsupported format for ${name} import: ${format}`,
+      'NotSupportedError',
+    );
   }
 
   // Get the modulus length from the key and add it to the algorithm
@@ -1043,33 +1043,30 @@ async function hmacImportKey(
   extractable: boolean,
   keyUsages: KeyUsage[],
 ): Promise<CryptoKey> {
-  // Validate usages
-  if (hasAnyNotIn(keyUsages, ['sign', 'verify'])) {
-    throw new Error('Unsupported key usage for an HMAC key');
-  }
+  const checkUsages = (): void => {
+    if (hasAnyNotIn(keyUsages, ['sign', 'verify'])) {
+      throw new Error('Unsupported key usage for an HMAC key');
+    }
+  };
 
   let keyObject: KeyObject;
 
   if (format === 'jwk') {
     const jwk = data as JWK;
 
-    // Validate JWK
     if (!jwk || typeof jwk !== 'object') {
       throw new Error('Invalid keyData');
     }
-
-    validateJwkExtAndKeyOps(jwk, extractable, keyUsages);
-
     if (jwk.kty !== 'oct') {
       throw new Error('Invalid JWK format for HMAC key');
     }
+    validateJwkStructure(jwk, extractable, keyUsages, 'sig');
+    checkUsages();
 
-    // Validate key length if specified
     if (algorithm.length !== undefined) {
       if (!jwk.k) {
         throw new Error('JWK missing key data');
       }
-      // Decode to check length
       const decoded = SBuffer.from(jwk.k, 'base64');
       const keyBitLength = decoded.length * 8;
       if (algorithm.length === 0) {
@@ -1082,14 +1079,22 @@ async function hmacImportKey(
 
     const handle =
       NitroModules.createHybridObject<KeyObjectHandle>('KeyObjectHandle');
-    const keyType = handle.initJwk(jwk, undefined);
-
+    let keyType: KeyType | undefined;
+    try {
+      keyType = handle.initJwk(jwk, undefined);
+    } catch (err) {
+      throw lazyDOMException('Invalid keyData', {
+        name: 'DataError',
+        cause: err,
+      });
+    }
     if (keyType === undefined || keyType !== 0) {
-      throw new Error('Failed to import HMAC JWK');
+      throw lazyDOMException('Invalid keyData', 'DataError');
     }
 
     keyObject = new SecretKeyObject(handle);
   } else if (format === 'raw') {
+    checkUsages();
     keyObject = createSecretKey(data as BinaryLike);
   } else {
     throw new Error(`Unable to import HMAC key with format ${format}`);
@@ -1115,16 +1120,17 @@ async function aesImportKey(
 ): Promise<CryptoKey> {
   const { name, length } = algorithm;
 
-  // Validate usages
   const validUsages: KeyUsage[] = [
     'encrypt',
     'decrypt',
     'wrapKey',
     'unwrapKey',
   ];
-  if (hasAnyNotIn(keyUsages, validUsages)) {
-    throw new Error(`Unsupported key usage for ${name}`);
-  }
+  const checkUsages = (): void => {
+    if (hasAnyNotIn(keyUsages, validUsages)) {
+      throw new Error(`Unsupported key usage for ${name}`);
+    }
+  };
 
   let keyObject: KeyObject;
   let actualLength: number;
@@ -1132,31 +1138,36 @@ async function aesImportKey(
   if (format === 'jwk') {
     const jwk = data as JWK;
 
-    // Validate JWK
     if (jwk.kty !== 'oct') {
       throw new Error('Invalid JWK format for AES key');
     }
-
-    validateJwkExtAndKeyOps(jwk, extractable, keyUsages);
+    validateJwkStructure(jwk, extractable, keyUsages, 'enc');
+    checkUsages();
 
     const handle =
       NitroModules.createHybridObject<KeyObjectHandle>('KeyObjectHandle');
-    const keyType = handle.initJwk(jwk, undefined);
-
+    let keyType: KeyType | undefined;
+    try {
+      keyType = handle.initJwk(jwk, undefined);
+    } catch (err) {
+      throw lazyDOMException('Invalid keyData', {
+        name: 'DataError',
+        cause: err,
+      });
+    }
     if (keyType === undefined || keyType !== 0) {
-      throw new Error('Failed to import AES JWK');
+      throw lazyDOMException('Invalid keyData', 'DataError');
     }
 
     keyObject = new SecretKeyObject(handle);
 
-    // Get actual key length from imported key
     const exported = keyObject.export();
     actualLength = exported.byteLength * 8;
   } else if (format === 'raw') {
+    checkUsages();
     const keyData = bufferLikeToArrayBuffer(data as BufferLike);
     actualLength = keyData.byteLength * 8;
 
-    // Validate key length
     if (![128, 192, 256].includes(actualLength)) {
       throw new Error('Invalid AES key length');
     }
@@ -1190,23 +1201,23 @@ function edImportKey(
 ): CryptoKey {
   const { name } = algorithm;
 
-  // Validate usages
   const isX = name === 'X25519' || name === 'X448';
   const allowedUsages: KeyUsage[] = isX
     ? ['deriveKey', 'deriveBits']
     : ['sign', 'verify'];
-
-  if (hasAnyNotIn(keyUsages, allowedUsages)) {
-    throw lazyDOMException(
-      `Unsupported key usage for ${name} key`,
-      'SyntaxError',
-    );
-  }
+  const checkUsages = (): void => {
+    if (hasAnyNotIn(keyUsages, allowedUsages)) {
+      throw lazyDOMException(
+        `Unsupported key usage for ${name} key`,
+        'SyntaxError',
+      );
+    }
+  };
 
   let keyObject: KeyObject;
 
   if (format === 'spki') {
-    // Import public key
+    checkUsages();
     const keyData = bufferLikeToArrayBuffer(data as BufferLike);
     keyObject = KeyObject.createKeyObject(
       'public',
@@ -1215,7 +1226,7 @@ function edImportKey(
       KeyEncoding.SPKI,
     );
   } else if (format === 'pkcs8') {
-    // Import private key
+    checkUsages();
     const keyData = bufferLikeToArrayBuffer(data as BufferLike);
     keyObject = KeyObject.createKeyObject(
       'private',
@@ -1224,20 +1235,31 @@ function edImportKey(
       KeyEncoding.PKCS8,
     );
   } else if (format === 'raw') {
-    // Raw format - public key only for Ed keys
+    checkUsages();
     const keyData = bufferLikeToArrayBuffer(data as BufferLike);
     const handle =
       NitroModules.createHybridObject<KeyObjectHandle>('KeyObjectHandle');
-    // For raw Ed keys, we need to create them differently
-    // Raw public keys are just the key bytes
-    handle.init(1, keyData); // 1 = public key type
+    handle.init(1, keyData);
     keyObject = new PublicKeyObject(handle);
   } else if (format === 'jwk') {
     const jwkData = data as JWK;
-    validateJwkExtAndKeyOps(jwkData, extractable, keyUsages);
+    if (!jwkData || typeof jwkData !== 'object') {
+      throw lazyDOMException('Invalid keyData', 'DataError');
+    }
+    const expectedUse = isX ? 'enc' : 'sig';
+    validateJwkStructure(jwkData, extractable, keyUsages, expectedUse);
+    checkUsages();
     const handle =
       NitroModules.createHybridObject<KeyObjectHandle>('KeyObjectHandle');
-    const keyType = handle.initJwk(jwkData);
+    let keyType: KeyType | undefined;
+    try {
+      keyType = handle.initJwk(jwkData);
+    } catch (err) {
+      throw lazyDOMException('Invalid JWK data', {
+        name: 'DataError',
+        cause: err,
+      });
+    }
     if (keyType === undefined) {
       throw lazyDOMException('Invalid JWK data', 'DataError');
     }
@@ -1260,8 +1282,6 @@ function pqcImportKeyObject(
   format: ImportFormat,
   data: BufferLike | JWK,
   name: string,
-  extractable: boolean,
-  keyUsages: KeyUsage[],
 ): { keyObject: KeyObject; isPublic: boolean } {
   if (format === 'spki') {
     return {
@@ -1314,20 +1334,18 @@ function pqcImportKeyObject(
     return { keyObject: new PrivateKeyObject(handle), isPublic: false };
   } else if (format === 'jwk') {
     const jwkData = data as JWK;
-    if (jwkData.kty !== 'AKP') {
-      throw lazyDOMException('Invalid JWK "kty" Parameter', 'DataError');
-    }
-    if (jwkData.alg !== name) {
-      throw lazyDOMException(
-        'JWK "alg" Parameter and algorithm name mismatch',
-        'DataError',
-      );
-    }
-    validateJwkExtAndKeyOps(jwkData, extractable, keyUsages);
     const isPublic = jwkData.priv === undefined;
     const handle =
       NitroModules.createHybridObject<KeyObjectHandle>('KeyObjectHandle');
-    const keyType = handle.initJwk(jwkData);
+    let keyType: KeyType | undefined;
+    try {
+      keyType = handle.initJwk(jwkData);
+    } catch (err) {
+      throw lazyDOMException('Invalid JWK data', {
+        name: 'DataError',
+        cause: err,
+      });
+    }
     if (keyType === undefined) {
       throw lazyDOMException('Invalid JWK data', 'DataError');
     }
@@ -1344,14 +1362,43 @@ function pqcImportKeyObject(
   );
 }
 
+// Per WebCrypto AKP JWK rules, public-vs-private is determined by the presence
+// of `priv`. For binary formats it follows from the format itself.
 function pqcIsPublicImport(
   format: ImportFormat,
   data: BufferLike | JWK,
 ): boolean {
   if (format === 'jwk') {
-    return (data as JWK).priv === undefined;
+    return (
+      typeof data === 'object' &&
+      data !== null &&
+      (data as JWK).priv === undefined
+    );
   }
   return format === 'spki' || format === 'raw';
+}
+
+function validatePqcJwk(
+  data: BufferLike | JWK,
+  name: string,
+  extractable: boolean,
+  keyUsages: KeyUsage[],
+  expectedUse: 'sig' | 'enc',
+): void {
+  if (typeof data !== 'object' || data === null) {
+    throw lazyDOMException('Invalid keyData', 'DataError');
+  }
+  const jwk = data as JWK;
+  if (jwk.kty !== 'AKP') {
+    throw lazyDOMException('Invalid JWK "kty" Parameter', 'DataError');
+  }
+  validateJwkStructure(jwk, extractable, keyUsages, expectedUse);
+  if (jwk.alg !== name) {
+    throw lazyDOMException(
+      'JWK "alg" Parameter and algorithm name mismatch',
+      'DataError',
+    );
+  }
 }
 
 function mldsaImportKey(
@@ -1362,6 +1409,9 @@ function mldsaImportKey(
   keyUsages: KeyUsage[],
 ): CryptoKey {
   const { name } = algorithm;
+  if (format === 'jwk') {
+    validatePqcJwk(data, name, extractable, keyUsages, 'sig');
+  }
   const isPublic = pqcIsPublicImport(format, data);
   if (hasAnyNotIn(keyUsages, isPublic ? ['verify'] : ['sign'])) {
     throw lazyDOMException(
@@ -1369,13 +1419,7 @@ function mldsaImportKey(
       'SyntaxError',
     );
   }
-  const { keyObject } = pqcImportKeyObject(
-    format,
-    data,
-    name,
-    extractable,
-    keyUsages,
-  );
+  const { keyObject } = pqcImportKeyObject(format, data, name);
   return new CryptoKey(keyObject, { name }, keyUsages, extractable);
 }
 
@@ -1387,6 +1431,9 @@ function mlkemImportKey(
   keyUsages: KeyUsage[],
 ): CryptoKey {
   const { name } = algorithm;
+  if (format === 'jwk') {
+    validatePqcJwk(data, name, extractable, keyUsages, 'enc');
+  }
   const isPublic = pqcIsPublicImport(format, data);
   const allowedUsages: KeyUsage[] = isPublic
     ? ['encapsulateBits', 'encapsulateKey']
@@ -1397,13 +1444,7 @@ function mlkemImportKey(
       'SyntaxError',
     );
   }
-  const { keyObject } = pqcImportKeyObject(
-    format,
-    data,
-    name,
-    extractable,
-    keyUsages,
-  );
+  const { keyObject } = pqcImportKeyObject(format, data, name);
   return new CryptoKey(keyObject, { name }, keyUsages, extractable);
 }
 

--- a/packages/react-native-quick-crypto/src/subtle.ts
+++ b/packages/react-native-quick-crypto/src/subtle.ts
@@ -1258,40 +1258,85 @@ function edImportKey(
 
 function pqcImportKeyObject(
   format: ImportFormat,
-  data: BufferLike,
+  data: BufferLike | JWK,
   name: string,
-): KeyObject {
+  extractable: boolean,
+  keyUsages: KeyUsage[],
+): { keyObject: KeyObject; isPublic: boolean } {
   if (format === 'spki') {
-    return KeyObject.createKeyObject(
-      'public',
-      bufferLikeToArrayBuffer(data),
-      KFormatType.DER,
-      KeyEncoding.SPKI,
-    );
+    return {
+      keyObject: KeyObject.createKeyObject(
+        'public',
+        bufferLikeToArrayBuffer(data as BufferLike),
+        KFormatType.DER,
+        KeyEncoding.SPKI,
+      ),
+      isPublic: true,
+    };
   } else if (format === 'pkcs8') {
-    return KeyObject.createKeyObject(
-      'private',
-      bufferLikeToArrayBuffer(data),
-      KFormatType.DER,
-      KeyEncoding.PKCS8,
-    );
+    return {
+      keyObject: KeyObject.createKeyObject(
+        'private',
+        bufferLikeToArrayBuffer(data as BufferLike),
+        KFormatType.DER,
+        KeyEncoding.PKCS8,
+      ),
+      isPublic: false,
+    };
   } else if (format === 'raw') {
     const handle =
       NitroModules.createHybridObject<KeyObjectHandle>('KeyObjectHandle');
-    if (!handle.initPqcRaw(name, bufferLikeToArrayBuffer(data), true)) {
+    if (
+      !handle.initPqcRaw(
+        name,
+        bufferLikeToArrayBuffer(data as BufferLike),
+        true,
+      )
+    ) {
       throw lazyDOMException(
         `Failed to import ${name} raw public key`,
         'DataError',
       );
     }
-    return new PublicKeyObject(handle);
+    return { keyObject: new PublicKeyObject(handle), isPublic: true };
   } else if (format === 'raw-seed') {
     const handle =
       NitroModules.createHybridObject<KeyObjectHandle>('KeyObjectHandle');
-    if (!handle.initPqcRaw(name, bufferLikeToArrayBuffer(data), false)) {
+    if (
+      !handle.initPqcRaw(
+        name,
+        bufferLikeToArrayBuffer(data as BufferLike),
+        false,
+      )
+    ) {
       throw lazyDOMException(`Failed to import ${name} raw seed`, 'DataError');
     }
-    return new PrivateKeyObject(handle);
+    return { keyObject: new PrivateKeyObject(handle), isPublic: false };
+  } else if (format === 'jwk') {
+    const jwkData = data as JWK;
+    if (jwkData.kty !== 'AKP') {
+      throw lazyDOMException('Invalid JWK "kty" Parameter', 'DataError');
+    }
+    if (jwkData.alg !== name) {
+      throw lazyDOMException(
+        'JWK "alg" Parameter and algorithm name mismatch',
+        'DataError',
+      );
+    }
+    validateJwkExtAndKeyOps(jwkData, extractable, keyUsages);
+    const isPublic = jwkData.priv === undefined;
+    const handle =
+      NitroModules.createHybridObject<KeyObjectHandle>('KeyObjectHandle');
+    const keyType = handle.initJwk(jwkData);
+    if (keyType === undefined) {
+      throw lazyDOMException('Invalid JWK data', 'DataError');
+    }
+    return {
+      keyObject: isPublic
+        ? new PublicKeyObject(handle)
+        : new PrivateKeyObject(handle),
+      isPublic,
+    };
   }
   throw lazyDOMException(
     `Unsupported format for ${name} import: ${format}`,
@@ -1299,39 +1344,51 @@ function pqcImportKeyObject(
   );
 }
 
+function pqcIsPublicImport(
+  format: ImportFormat,
+  data: BufferLike | JWK,
+): boolean {
+  if (format === 'jwk') {
+    return (data as JWK).priv === undefined;
+  }
+  return format === 'spki' || format === 'raw';
+}
+
 function mldsaImportKey(
   format: ImportFormat,
-  data: BufferLike,
+  data: BufferLike | JWK,
   algorithm: SubtleAlgorithm,
   extractable: boolean,
   keyUsages: KeyUsage[],
 ): CryptoKey {
   const { name } = algorithm;
-  const isPublicFormat = format === 'spki' || format === 'raw';
-  if (hasAnyNotIn(keyUsages, isPublicFormat ? ['verify'] : ['sign'])) {
+  const isPublic = pqcIsPublicImport(format, data);
+  if (hasAnyNotIn(keyUsages, isPublic ? ['verify'] : ['sign'])) {
     throw lazyDOMException(
       `Unsupported key usage for ${name} key`,
       'SyntaxError',
     );
   }
-  return new CryptoKey(
-    pqcImportKeyObject(format, data, name),
-    { name },
-    keyUsages,
+  const { keyObject } = pqcImportKeyObject(
+    format,
+    data,
+    name,
     extractable,
+    keyUsages,
   );
+  return new CryptoKey(keyObject, { name }, keyUsages, extractable);
 }
 
 function mlkemImportKey(
   format: ImportFormat,
-  data: BufferLike,
+  data: BufferLike | JWK,
   algorithm: SubtleAlgorithm,
   extractable: boolean,
   keyUsages: KeyUsage[],
 ): CryptoKey {
   const { name } = algorithm;
-  const isPublicFormat = format === 'spki' || format === 'raw';
-  const allowedUsages: KeyUsage[] = isPublicFormat
+  const isPublic = pqcIsPublicImport(format, data);
+  const allowedUsages: KeyUsage[] = isPublic
     ? ['encapsulateBits', 'encapsulateKey']
     : ['decapsulateBits', 'decapsulateKey'];
   if (hasAnyNotIn(keyUsages, allowedUsages)) {
@@ -1340,12 +1397,14 @@ function mlkemImportKey(
       'SyntaxError',
     );
   }
-  return new CryptoKey(
-    pqcImportKeyObject(format, data, name),
-    { name },
-    keyUsages,
+  const { keyObject } = pqcImportKeyObject(
+    format,
+    data,
+    name,
     extractable,
+    keyUsages,
   );
+  return new CryptoKey(keyObject, { name }, keyUsages, extractable);
 }
 
 const exportKeySpki = async (
@@ -1584,6 +1643,18 @@ const exportKeyJWK = (key: CryptoKey): ArrayBuffer | unknown => {
     case 'X25519':
     // Fall through
     case 'X448':
+      return jwk;
+    case 'ML-DSA-44':
+    // Fall through
+    case 'ML-DSA-65':
+    // Fall through
+    case 'ML-DSA-87':
+    // Fall through
+    case 'ML-KEM-512':
+    // Fall through
+    case 'ML-KEM-768':
+    // Fall through
+    case 'ML-KEM-1024':
       return jwk;
     case 'AES-CTR':
     // Fall through
@@ -2768,7 +2839,7 @@ export class Subtle {
       case 'ML-DSA-87':
         result = mldsaImportKey(
           format,
-          data as BufferLike,
+          data as BufferLike | JWK,
           normalizedAlgorithm,
           extractable,
           keyUsages,
@@ -2781,7 +2852,7 @@ export class Subtle {
       case 'ML-KEM-1024':
         result = mlkemImportKey(
           format,
-          data as BufferLike,
+          data as BufferLike | JWK,
           normalizedAlgorithm,
           extractable,
           keyUsages,

--- a/packages/react-native-quick-crypto/src/utils/errors.ts
+++ b/packages/react-native-quick-crypto/src/utils/errors.ts
@@ -6,10 +6,8 @@ type DOMName =
     };
 
 export function lazyDOMException(message: string, domName: DOMName): Error {
-  let cause = '';
-  if (typeof domName !== 'string') {
-    cause = `\nCaused by: ${domName.cause}`;
-  }
-
-  return new Error(`[${domName}]: ${message}${cause}`);
+  const name = typeof domName === 'string' ? domName : domName.name;
+  const cause =
+    typeof domName === 'string' ? '' : `\nCaused by: ${domName.cause}`;
+  return new Error(`[${name}]: ${message}${cause}`);
 }

--- a/packages/react-native-quick-crypto/src/utils/types.ts
+++ b/packages/react-native-quick-crypto/src/utils/types.ts
@@ -324,7 +324,7 @@ export type AsymmetricKeyType =
   | CFRGKeyPairType
   | PQCKeyPairType;
 
-type JWKkty = 'AES' | 'RSA' | 'EC' | 'oct' | 'OKP';
+type JWKkty = 'AES' | 'RSA' | 'EC' | 'oct' | 'OKP' | 'AKP';
 type JWKuse = 'sig' | 'enc';
 
 export interface JWK {
@@ -349,6 +349,8 @@ export interface JWK {
   dp?: string;
   dq?: string;
   qi?: string;
+  pub?: string;
+  priv?: string;
   ext?: boolean;
 }
 

--- a/packages/react-native-quick-crypto/src/utils/validation.ts
+++ b/packages/react-native-quick-crypto/src/utils/validation.ts
@@ -1,5 +1,5 @@
 import { Buffer as SBuffer } from 'safe-buffer';
-import type { BinaryLike, BufferLike, KeyUsage } from './types';
+import type { BinaryLike, BufferLike, JWK, KeyUsage } from './types';
 import { lazyDOMException } from './errors';
 
 // The maximum buffer size that we'll support in the WebCrypto impl
@@ -119,6 +119,52 @@ export const validateKeyOps = (
     }
   }
 };
+
+// WebCrypto JWK import structural validation, mirroring Node's
+// `internal/crypto/webcrypto_util.validateJwk` + `validateKeyOps`:
+//   - `ext`: if present and false, `extractable` must also be false
+//   - `use`: if `keyUsages` is non-empty and `use` is present, must equal
+//     the algorithm's expected use ('sig' or 'enc')
+//   - `key_ops`: must be an array, must not contain duplicates, and every
+//     requested usage must appear in it
+export function validateJwkStructure(
+  jwk: JWK,
+  extractable: boolean,
+  keyUsages: KeyUsage[],
+  expectedUse: 'sig' | 'enc',
+): void {
+  if (jwk.ext === false && extractable) {
+    throw lazyDOMException(
+      'JWK "ext" is false but extractable was requested',
+      'DataError',
+    );
+  }
+  if (keyUsages.length > 0 && jwk.use !== undefined) {
+    if (jwk.use !== expectedUse) {
+      throw lazyDOMException('Invalid JWK "use" Parameter', 'DataError');
+    }
+  }
+  if (jwk.key_ops !== undefined) {
+    if (!Array.isArray(jwk.key_ops)) {
+      throw lazyDOMException('JWK "key_ops" must be an array', 'DataError');
+    }
+    const seen = new Set<string>();
+    for (const op of jwk.key_ops) {
+      if (seen.has(op)) {
+        throw lazyDOMException('Duplicate key operation', 'DataError');
+      }
+      seen.add(op);
+    }
+    for (const usage of keyUsages) {
+      if (!jwk.key_ops.includes(usage)) {
+        throw lazyDOMException(
+          `JWK "key_ops" does not include requested usage "${usage}"`,
+          'DataError',
+        );
+      }
+    }
+  }
+}
 
 export function hasAnyNotIn(set: string[], checks: string[]) {
   for (const s of set) {


### PR DESCRIPTION
## Summary

Adds WebCrypto JWK support for ML-DSA-44/65/87 and ML-KEM-512/768/1024 using Node's `kty: 'AKP'` encoding. Public keys carry the raw public bytes in `pub`; private keys add the seed in `priv`. On private-key import the public key is re-derived from the seed and constant-time compared (`CRYPTO_memcmp`) against the supplied `pub`.

While here, hardened JWK import validation across **all** importers (kmac, rsa, hmac, aes, ec, ed, mldsa, mlkem) so the codebase aligns with Node's `validateJwk` / `validateKeyOps` and the WebCrypto spec.

## Changes

- **PQC JWK** (C++ + TS): export/import for ML-DSA and ML-KEM via `kty: 'AKP'` with `pub`/`priv` (seed). Guarded by `OPENSSL_VERSION_NUMBER >= 0x30500000L`. Constant-time pub/derived-pub comparison on private import.
- **Centralized `validateJwkStructure`** (`utils/validation.ts`): one place for `ext`, `use`, `key_ops` array shape, `key_ops` duplicate detection, and `key_ops`-covers-usages. Mirrors Node's `validateJwk` + `validateKeyOps`.
- **Validation order fix**: every JWK importer now validates JWK structure (kty/use/key_ops/ext/alg) **before** key-usage validation — matches Node and the spec. Previously usage checks ran first, which produced `SyntaxError` for cases where Node throws `DataError`.
- **`DataError` propagation**: every `handle.initJwk()` call site is wrapped in try/catch so C++ runtime errors surface as `DataError` DOMExceptions instead of generic `Error`s.
- **Type guard in `pqcIsPublicImport`**: a non-object passed at `format === 'jwk'` is no longer silently treated as a public key.
- **`lazyDOMException` fix**: object-form `domName` was producing `[object Object]` in error messages — now correctly uses `domName.name` and appends the cause.
- Restored `workspace:*` for the example app dep and stopped the release bumper from rewriting it.
- Doc table: ML-KEM JWK column flipped from `—` to ✅.

## Testing

- ML-DSA & ML-KEM JWK round-trip tests (export → import → sign/verify or encapsulate/decapsulate) for all 6 variants
- Negative tests: wrong kty, alg mismatch
- All existing JWK error-message expectations preserved (verified via test message snippets)
- `bun tsc` clean across both packages
- Pre-commit hook (lint-staged + format + tsc + bob build) passes

Closes #996.