### PR TITLE
feat: PQC PKCS#8 seed validation for ML-DSA and ML-KEM

### DIFF
--- a/example/src/tests/subtle/import_export.ts
+++ b/example/src/tests/subtle/import_export.ts
@@ -2283,6 +2283,43 @@ test(SUITE, 'ML-DSA-44 importKey rejects jwk alg mismatch', async () => {
   );
 });
 
+// --- ML-DSA seedless PKCS#8 import rejection (issue #997) ---
+
+const MLDSA_SEEDLESS_PKCS8_LENGTHS: Record<MlDsaVariant, number> = {
+  'ML-DSA-44': 2588,
+  'ML-DSA-65': 4060,
+  'ML-DSA-87': 4924,
+};
+
+for (const variant of MLDSA_VARIANTS) {
+  test(SUITE, `${variant} pkcs8 import rejects seedless key`, async () => {
+    const seedless = new Uint8Array(MLDSA_SEEDLESS_PKCS8_LENGTHS[variant]);
+    await assertThrowsAsync(
+      async () =>
+        await subtle.importKey('pkcs8', seedless, { name: variant }, true, [
+          'sign',
+        ]),
+      'NotSupportedError',
+    );
+  });
+
+  test(
+    SUITE,
+    `${variant} pkcs8 export produces 54-byte seed-only encoding`,
+    async () => {
+      const keyPair = (await subtle.generateKey({ name: variant }, true, [
+        'sign',
+        'verify',
+      ])) as CryptoKeyPair;
+      const exported = (await subtle.exportKey(
+        'pkcs8',
+        keyPair.privateKey as CryptoKey,
+      )) as ArrayBuffer;
+      expect(exported.byteLength).to.equal(54);
+    },
+  );
+}
+
 // --- ML-DSA raw-public and raw-seed export/import tests ---
 // 'raw-public' is normalized to 'raw' internally (public key bytes)
 // 'raw-seed' passes through directly (64-byte private seed)
@@ -2682,6 +2719,78 @@ test(SUITE, 'ML-KEM-768 importKey raw rejects bad usages', async () => {
       ),
     'Unsupported key usage',
   );
+});
+
+// --- ML-KEM seedless PKCS#8 import rejection + export length (issue #997) ---
+
+const MLKEM_SEEDLESS_PKCS8_LENGTHS: Record<
+  (typeof MLKEM_VARIANTS)[number],
+  number
+> = {
+  'ML-KEM-512': 1660,
+  'ML-KEM-768': 2428,
+  'ML-KEM-1024': 3196,
+};
+
+for (const variant of MLKEM_VARIANTS) {
+  test(SUITE, `${variant} pkcs8 import rejects seedless key`, async () => {
+    const seedless = new Uint8Array(MLKEM_SEEDLESS_PKCS8_LENGTHS[variant]);
+    await assertThrowsAsync(
+      async () =>
+        await subtle.importKey('pkcs8', seedless, { name: variant }, true, [
+          'decapsulateBits',
+        ]),
+      'NotSupportedError',
+    );
+  });
+
+  test(
+    SUITE,
+    `${variant} pkcs8 export produces 86-byte seed-only encoding`,
+    async () => {
+      const keyPair = (await subtle.generateKey({ name: variant }, true, [
+        'encapsulateBits',
+        'decapsulateBits',
+      ])) as CryptoKeyPair;
+      const exported = (await subtle.exportKey(
+        'pkcs8',
+        keyPair.privateKey as CryptoKey,
+      )) as ArrayBuffer;
+      expect(exported.byteLength).to.equal(86);
+    },
+  );
+}
+
+test(SUITE, 'ML-KEM-768 pkcs8 round-trip + decapsulate', async () => {
+  const keyPair = (await subtle.generateKey({ name: 'ML-KEM-768' }, true, [
+    'encapsulateBits',
+    'decapsulateBits',
+  ])) as CryptoKeyPair;
+
+  const exported = (await subtle.exportKey(
+    'pkcs8',
+    keyPair.privateKey as CryptoKey,
+  )) as ArrayBuffer;
+  expect(exported.byteLength).to.equal(86);
+
+  const imported = await subtle.importKey(
+    'pkcs8',
+    exported,
+    { name: 'ML-KEM-768' },
+    true,
+    ['decapsulateBits'],
+  );
+
+  const { sharedKey, ciphertext } = await subtle.encapsulateBits(
+    { name: 'ML-KEM-768' },
+    keyPair.publicKey as CryptoKey,
+  );
+  const recovered = await subtle.decapsulateBits(
+    { name: 'ML-KEM-768' },
+    imported,
+    ciphertext,
+  );
+  expect(new Uint8Array(recovered)).to.deep.equal(new Uint8Array(sharedKey));
 });
 
 // --- Ed25519/Ed448 raw import/export Tests ---

--- a/example/src/tests/subtle/import_export.ts
+++ b/example/src/tests/subtle/import_export.ts
@@ -28,6 +28,7 @@ import {
   // createPublicKey, // TODO: for 'bad usages' test
   // createPrivateKey, // TODO: for 'bad usages' test
   getRandomValues,
+  PQC_SEEDLESS_PKCS8_LENGTHS,
   subtle,
 } from 'react-native-quick-crypto';
 import { MLKEM_VARIANTS } from './mlkem_constants';
@@ -2283,17 +2284,11 @@ test(SUITE, 'ML-DSA-44 importKey rejects jwk alg mismatch', async () => {
   );
 });
 
-// --- ML-DSA seedless PKCS#8 import rejection (issue #997) ---
-
-const MLDSA_SEEDLESS_PKCS8_LENGTHS: Record<MlDsaVariant, number> = {
-  'ML-DSA-44': 2588,
-  'ML-DSA-65': 4060,
-  'ML-DSA-87': 4924,
-};
+// --- ML-DSA seedless PKCS#8 import rejection (PR #997) ---
 
 for (const variant of MLDSA_VARIANTS) {
   test(SUITE, `${variant} pkcs8 import rejects seedless key`, async () => {
-    const seedless = new Uint8Array(MLDSA_SEEDLESS_PKCS8_LENGTHS[variant]);
+    const seedless = new Uint8Array(PQC_SEEDLESS_PKCS8_LENGTHS[variant] ?? 0);
     await assertThrowsAsync(
       async () =>
         await subtle.importKey('pkcs8', seedless, { name: variant }, true, [
@@ -2319,6 +2314,37 @@ for (const variant of MLDSA_VARIANTS) {
     },
   );
 }
+
+test(SUITE, 'ML-DSA-65 pkcs8 round-trip + sign/verify', async () => {
+  const keyPair = (await subtle.generateKey({ name: 'ML-DSA-65' }, true, [
+    'sign',
+    'verify',
+  ])) as CryptoKeyPair;
+
+  const exported = (await subtle.exportKey(
+    'pkcs8',
+    keyPair.privateKey as CryptoKey,
+  )) as ArrayBuffer;
+  expect(exported.byteLength).to.equal(54);
+
+  const imported = await subtle.importKey(
+    'pkcs8',
+    exported,
+    { name: 'ML-DSA-65' },
+    true,
+    ['sign'],
+  );
+
+  const message = new TextEncoder().encode('round-trip test');
+  const signature = await subtle.sign({ name: 'ML-DSA-65' }, imported, message);
+  const verified = await subtle.verify(
+    { name: 'ML-DSA-65' },
+    keyPair.publicKey as CryptoKey,
+    signature,
+    message,
+  );
+  expect(verified).to.equal(true);
+});
 
 // --- ML-DSA raw-public and raw-seed export/import tests ---
 // 'raw-public' is normalized to 'raw' internally (public key bytes)
@@ -2721,20 +2747,11 @@ test(SUITE, 'ML-KEM-768 importKey raw rejects bad usages', async () => {
   );
 });
 
-// --- ML-KEM seedless PKCS#8 import rejection + export length (issue #997) ---
-
-const MLKEM_SEEDLESS_PKCS8_LENGTHS: Record<
-  (typeof MLKEM_VARIANTS)[number],
-  number
-> = {
-  'ML-KEM-512': 1660,
-  'ML-KEM-768': 2428,
-  'ML-KEM-1024': 3196,
-};
+// --- ML-KEM seedless PKCS#8 import rejection + export length (PR #997) ---
 
 for (const variant of MLKEM_VARIANTS) {
   test(SUITE, `${variant} pkcs8 import rejects seedless key`, async () => {
-    const seedless = new Uint8Array(MLKEM_SEEDLESS_PKCS8_LENGTHS[variant]);
+    const seedless = new Uint8Array(PQC_SEEDLESS_PKCS8_LENGTHS[variant] ?? 0);
     await assertThrowsAsync(
       async () =>
         await subtle.importKey('pkcs8', seedless, { name: variant }, true, [

--- a/packages/react-native-quick-crypto/cpp/keys/HybridKeyObjectHandle.cpp
+++ b/packages/react-native-quick-crypto/cpp/keys/HybridKeyObjectHandle.cpp
@@ -1,4 +1,5 @@
 #include <cstdio>
+#include <mutex>
 #include <stdexcept>
 
 #include "../utils/base64.h"
@@ -10,9 +11,31 @@
 #include <openssl/ec.h>
 #include <openssl/evp.h>
 #include <openssl/obj_mac.h>
+#include <openssl/provider.h>
 #include <openssl/rsa.h>
 
 namespace margelo::nitro::crypto {
+
+#if OPENSSL_VERSION_NUMBER >= 0x30600000L
+// Configure loaded providers to prefer seed-only PKCS#8 output for ML-DSA /
+// ML-KEM, falling back to priv-only when no seed is available. Without this,
+// OpenSSL defaults to "seed-priv" — a longer encoding that bundles both —
+// which breaks interop with Node and PR #997's exact-length export check.
+// Mirrors src/crypto/crypto_util.cc in Node.
+static void configurePqcOutputFormats() {
+  static std::once_flag once;
+  std::call_once(once, []() {
+    OSSL_PROVIDER_do_all(
+        nullptr,
+        [](OSSL_PROVIDER* provider, void*) -> int {
+          OSSL_PROVIDER_add_conf_parameter(provider, "ml-kem.output_formats", "seed-only,priv-only");
+          OSSL_PROVIDER_add_conf_parameter(provider, "ml-dsa.output_formats", "seed-only,priv-only");
+          return 1;
+        },
+        nullptr);
+  });
+}
+#endif
 
 // Helper functions for base64url encoding/decoding with BIGNUMs
 static std::string bn_to_base64url(const BIGNUM* bn, size_t expected_size = 0) {
@@ -169,6 +192,18 @@ std::shared_ptr<ArrayBuffer> HybridKeyObjectHandle::exportKey(std::optional<KFor
     // If SPKI is requested, export as public key (works for both public and private keys)
     // This allows extracting the public key from a private key
     bool exportAsPublic = (exportType == KeyEncoding::SPKI) || (keyType == KeyType::PUBLIC);
+
+#if OPENSSL_VERSION_NUMBER >= 0x30600000L
+    if (!exportAsPublic && exportType == KeyEncoding::PKCS8) {
+      const char* typeName = EVP_PKEY_get0_type_name(pkey.get());
+      if (typeName != nullptr) {
+        std::string name(typeName);
+        if (name.starts_with("ML-KEM-") || name.starts_with("ML-DSA-")) {
+          configurePqcOutputFormats();
+        }
+      }
+    }
+#endif
 
     // Create encoding config
     if (exportAsPublic) {

--- a/packages/react-native-quick-crypto/cpp/keys/HybridKeyObjectHandle.cpp
+++ b/packages/react-native-quick-crypto/cpp/keys/HybridKeyObjectHandle.cpp
@@ -20,7 +20,7 @@ namespace margelo::nitro::crypto {
 // Configure loaded providers to prefer seed-only PKCS#8 output for ML-DSA /
 // ML-KEM, falling back to priv-only when no seed is available. Without this,
 // OpenSSL defaults to "seed-priv" — a longer encoding that bundles both —
-// which breaks interop with Node and PR #997's exact-length export check.
+// which breaks interop with Node and the exact-length export check in subtle.ts.
 // Mirrors src/crypto/crypto_util.cc in Node.
 static void configurePqcOutputFormats() {
   static std::once_flag once;
@@ -36,6 +36,15 @@ static void configurePqcOutputFormats() {
   });
 }
 #endif
+
+HybridKeyObjectHandle::HybridKeyObjectHandle() : HybridObject(TAG) {
+#if OPENSSL_VERSION_NUMBER >= 0x30600000L
+  // Configure once on first handle construction. Providers are guaranteed
+  // loaded by this point (any prior crypto op routed through ncrypto), and
+  // the call_once flag makes subsequent constructions cheap.
+  configurePqcOutputFormats();
+#endif
+}
 
 // Helper functions for base64url encoding/decoding with BIGNUMs
 static std::string bn_to_base64url(const BIGNUM* bn, size_t expected_size = 0) {
@@ -192,18 +201,6 @@ std::shared_ptr<ArrayBuffer> HybridKeyObjectHandle::exportKey(std::optional<KFor
     // If SPKI is requested, export as public key (works for both public and private keys)
     // This allows extracting the public key from a private key
     bool exportAsPublic = (exportType == KeyEncoding::SPKI) || (keyType == KeyType::PUBLIC);
-
-#if OPENSSL_VERSION_NUMBER >= 0x30600000L
-    if (!exportAsPublic && exportType == KeyEncoding::PKCS8) {
-      const char* typeName = EVP_PKEY_get0_type_name(pkey.get());
-      if (typeName != nullptr) {
-        std::string name(typeName);
-        if (name.starts_with("ML-KEM-") || name.starts_with("ML-DSA-")) {
-          configurePqcOutputFormats();
-        }
-      }
-    }
-#endif
 
     // Create encoding config
     if (exportAsPublic) {

--- a/packages/react-native-quick-crypto/cpp/keys/HybridKeyObjectHandle.hpp
+++ b/packages/react-native-quick-crypto/cpp/keys/HybridKeyObjectHandle.hpp
@@ -15,7 +15,7 @@ namespace margelo::nitro::crypto {
 
 class HybridKeyObjectHandle : public HybridKeyObjectHandleSpec {
  public:
-  HybridKeyObjectHandle() : HybridObject(TAG) {}
+  HybridKeyObjectHandle();
 
  public:
   std::shared_ptr<ArrayBuffer> exportKey(std::optional<KFormatType> format, std::optional<KeyEncoding> type,

--- a/packages/react-native-quick-crypto/src/subtle.ts
+++ b/packages/react-native-quick-crypto/src/subtle.ts
@@ -1278,6 +1278,19 @@ function edImportKey(
   return new CryptoKey(keyObject, { name }, keyUsages, extractable);
 }
 
+// Lengths (in bytes) of seedless ML-DSA / ML-KEM PKCS#8 encodings. A PKCS#8
+// blob of exactly this length contains only the expanded private key with no
+// seed; Node rejects these to keep cross-implementation interop intact.
+// Refs: ~/dev/node/lib/internal/crypto/ml_dsa.js:158-174, ml_kem.js:157-173.
+const PQC_SEEDLESS_PKCS8_LENGTHS: Readonly<Record<string, number>> = {
+  'ML-DSA-44': 2588,
+  'ML-DSA-65': 4060,
+  'ML-DSA-87': 4924,
+  'ML-KEM-512': 1660,
+  'ML-KEM-768': 2428,
+  'ML-KEM-1024': 3196,
+};
+
 function pqcImportKeyObject(
   format: ImportFormat,
   data: BufferLike | JWK,
@@ -1294,10 +1307,18 @@ function pqcImportKeyObject(
       isPublic: true,
     };
   } else if (format === 'pkcs8') {
+    const ab = bufferLikeToArrayBuffer(data as BufferLike);
+    if (ab.byteLength === PQC_SEEDLESS_PKCS8_LENGTHS[name]) {
+      const family = name.startsWith('ML-DSA') ? 'ML-DSA' : 'ML-KEM';
+      throw lazyDOMException(
+        `Importing an ${family} PKCS#8 key without a seed is not supported`,
+        'NotSupportedError',
+      );
+    }
     return {
       keyObject: KeyObject.createKeyObject(
         'private',
-        bufferLikeToArrayBuffer(data as BufferLike),
+        ab,
         KFormatType.DER,
         KeyEncoding.PKCS8,
       ),
@@ -1551,22 +1572,26 @@ const exportKeyPkcs8 = async (
     case 'ML-DSA-65':
     // Fall through
     case 'ML-DSA-87':
-      if (key.type === 'private') {
-        // Export ML-DSA key in PKCS8 DER format
-        return bufferLikeToArrayBuffer(
-          key.keyObject.handle.exportKey(KFormatType.DER, KeyEncoding.PKCS8),
-        );
-      }
-      break;
+    // Fall through
     case 'ML-KEM-512':
     // Fall through
     case 'ML-KEM-768':
     // Fall through
     case 'ML-KEM-1024':
       if (key.type === 'private') {
-        return bufferLikeToArrayBuffer(
+        const ab = bufferLikeToArrayBuffer(
           key.keyObject.handle.exportKey(KFormatType.DER, KeyEncoding.PKCS8),
         );
+        // 22 bytes of PKCS#8 ASN.1 + seed (32 ML-DSA, 64 ML-KEM). Guards
+        // against a seedless KeyObject that was wrapped via toCryptoKey.
+        const expected = key.algorithm.name.startsWith('ML-DSA') ? 54 : 86;
+        if (ab.byteLength !== expected) {
+          throw lazyDOMException(
+            'The operation failed for an operation-specific reason',
+            'OperationError',
+          );
+        }
+        return ab;
       }
       break;
   }

--- a/packages/react-native-quick-crypto/src/subtle.ts
+++ b/packages/react-native-quick-crypto/src/subtle.ts
@@ -1281,14 +1281,26 @@ function edImportKey(
 // Lengths (in bytes) of seedless ML-DSA / ML-KEM PKCS#8 encodings. A PKCS#8
 // blob of exactly this length contains only the expanded private key with no
 // seed; Node rejects these to keep cross-implementation interop intact.
-// Refs: ~/dev/node/lib/internal/crypto/ml_dsa.js:158-174, ml_kem.js:157-173.
-const PQC_SEEDLESS_PKCS8_LENGTHS: Readonly<Record<string, number>> = {
+// Refs: node lib/internal/crypto/ml_dsa.js (mlDsaImportKey, pkcs8 case)
+//       node lib/internal/crypto/ml_kem.js (mlKemImportKey, pkcs8 case)
+export const PQC_SEEDLESS_PKCS8_LENGTHS: Readonly<Record<string, number>> = {
   'ML-DSA-44': 2588,
   'ML-DSA-65': 4060,
   'ML-DSA-87': 4924,
   'ML-KEM-512': 1660,
   'ML-KEM-768': 2428,
   'ML-KEM-1024': 3196,
+};
+
+// Map from PQC algorithm name to display family. Used to render the
+// import-rejection error message in the same form Node emits.
+const PQC_FAMILY: Readonly<Record<string, 'ML-DSA' | 'ML-KEM'>> = {
+  'ML-DSA-44': 'ML-DSA',
+  'ML-DSA-65': 'ML-DSA',
+  'ML-DSA-87': 'ML-DSA',
+  'ML-KEM-512': 'ML-KEM',
+  'ML-KEM-768': 'ML-KEM',
+  'ML-KEM-1024': 'ML-KEM',
 };
 
 function pqcImportKeyObject(
@@ -1308,8 +1320,11 @@ function pqcImportKeyObject(
     };
   } else if (format === 'pkcs8') {
     const ab = bufferLikeToArrayBuffer(data as BufferLike);
-    if (ab.byteLength === PQC_SEEDLESS_PKCS8_LENGTHS[name]) {
-      const family = name.startsWith('ML-DSA') ? 'ML-DSA' : 'ML-KEM';
+    const family = PQC_FAMILY[name];
+    if (
+      family !== undefined &&
+      ab.byteLength === PQC_SEEDLESS_PKCS8_LENGTHS[name]
+    ) {
       throw lazyDOMException(
         `Importing an ${family} PKCS#8 key without a seed is not supported`,
         'NotSupportedError',


### PR DESCRIPTION
## Summary

Closes #997.

Aligns ML-DSA / ML-KEM PKCS#8 import and export with Node's WebCrypto:

- **Import**: rejects "seedless" PKCS#8 blobs (priv-only, no seed) with `NotSupportedError` — identified by exact byte length (matches Node's `lib/internal/crypto/ml_dsa.js` and `ml_kem.js`).
- **Export**: configures OpenSSL providers to prefer `seed-only,priv-only` PKCS#8 output (mirrors `node/src/crypto/crypto_util.cc`) so RNQC emits the compact 54-byte (ML-DSA) / 86-byte (ML-KEM) encoding by default. Adds a defensive length check that throws `OperationError` if a seedless `KeyObject` was wrapped via `toCryptoKey` and slipped past the import guard.

## Changes

- `packages/react-native-quick-crypto/src/subtle.ts`
  - Export `PQC_SEEDLESS_PKCS8_LENGTHS` and add `PQC_FAMILY` lookup; reject seedless PKCS#8 imports with the same error message Node emits.
  - Add post-export length guard for ML-DSA (54) / ML-KEM (86) PKCS#8 in `exportKeyPkcs8`.
- `packages/react-native-quick-crypto/cpp/keys/HybridKeyObjectHandle.{cpp,hpp}`
  - Configure provider `ml-{kem,dsa}.output_formats` to `seed-only,priv-only` once, on first `HybridKeyObjectHandle` construction, via `std::call_once`. Gated to OpenSSL ≥ 3.6 (`OSSL_PROVIDER_add_conf_parameter`).
- `example/src/tests/subtle/import_export.ts`
  - Seedless-import rejection tests for all six variants.
  - Export-length tests for all six variants.
  - Round-trip + sign/verify (ML-DSA-65) and round-trip + decapsulate (ML-KEM-768).

## Test plan

- [ ] `subtle: ML-DSA-{44,65,87} pkcs8 import rejects seedless key` — `NotSupportedError` thrown with Node-matching message
- [ ] `subtle: ML-KEM-{512,768,1024} pkcs8 import rejects seedless key` — `NotSupportedError` thrown
- [ ] `subtle: ML-DSA-{44,65,87} pkcs8 export produces 54-byte seed-only encoding`
- [ ] `subtle: ML-KEM-{512,768,1024} pkcs8 export produces 86-byte seed-only encoding`
- [ ] `subtle: ML-DSA-65 pkcs8 round-trip + sign/verify`
- [ ] `subtle: ML-KEM-768 pkcs8 round-trip + decapsulate`