### PR TITLE
fix: deduplicate and canonicalize CryptoKey.usages

### DIFF
--- a/example/src/hooks/useTestsList.ts
+++ b/example/src/hooks/useTestsList.ts
@@ -45,6 +45,7 @@ import '../tests/subtle/sharedarraybuffer_rejection';
 import '../tests/subtle/sign_verify';
 import '../tests/subtle/supports';
 import '../tests/subtle/getPublicKey';
+import '../tests/subtle/usage_canonicalization';
 import '../tests/subtle/wrap_unwrap';
 import '../tests/utils/utils_tests';
 import '../tests/utils/encoding_tests';

--- a/example/src/tests/subtle/usage_canonicalization.ts
+++ b/example/src/tests/subtle/usage_canonicalization.ts
@@ -1,0 +1,345 @@
+import { expect } from 'chai';
+import type {
+  CryptoKey,
+  JWK,
+  WebCryptoKeyPair,
+} from 'react-native-quick-crypto';
+import crypto, { subtle } from 'react-native-quick-crypto';
+import { test } from '../util';
+
+// Issue #1000 / Node commit fe7ebccd0ce ("crypto: deduplicate and canonicalize
+// CryptoKey usages"). `CryptoKey.usages` (and JWK `key_ops` derived from it)
+// must be deduplicated and returned in this canonical order:
+//
+//   encrypt, decrypt, sign, verify, deriveKey, deriveBits,
+//   wrapKey, unwrapKey, encapsulateKey, encapsulateBits,
+//   decapsulateKey, decapsulateBits
+
+const SUITE = 'subtle.usage-canonicalization';
+
+// --- generateKey: symmetric (single CryptoKey) ----------------------------
+
+const symmetricVectors: Array<{
+  name: string;
+  // SubtleAlgorithm types vary across algorithms; loose typing is fine here.
+  algorithm: object;
+  usages: string[];
+  expected: string[];
+}> = [
+  {
+    name: 'HMAC',
+    algorithm: { name: 'HMAC', hash: 'SHA-256' },
+    usages: ['verify', 'sign', 'verify', 'sign'],
+    expected: ['sign', 'verify'],
+  },
+  {
+    name: 'AES-CTR',
+    algorithm: { name: 'AES-CTR', length: 128 },
+    usages: [
+      'wrapKey',
+      'decrypt',
+      'encrypt',
+      'unwrapKey',
+      'wrapKey',
+      'encrypt',
+    ],
+    expected: ['encrypt', 'decrypt', 'wrapKey', 'unwrapKey'],
+  },
+  {
+    name: 'AES-CBC dedup-only',
+    algorithm: { name: 'AES-CBC', length: 128 },
+    usages: ['encrypt', 'encrypt'],
+    expected: ['encrypt'],
+  },
+  {
+    name: 'AES-GCM',
+    algorithm: { name: 'AES-GCM', length: 128 },
+    usages: ['decrypt', 'encrypt', 'decrypt'],
+    expected: ['encrypt', 'decrypt'],
+  },
+];
+
+for (const { name, algorithm, usages, expected } of symmetricVectors) {
+  test(SUITE, `generateKey ${name} usages canonical + deduped`, async () => {
+    const key = (await subtle.generateKey(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      algorithm as any,
+      true,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      usages as any,
+    )) as CryptoKey;
+    expect(key.usages).to.deep.equal(expected);
+    expect(key.usages.length).to.equal(expected.length);
+  });
+}
+
+// --- generateKey: asymmetric (CryptoKeyPair) ------------------------------
+
+type PairVector = {
+  name: string;
+  algorithm: object;
+  usages: string[];
+  publicExpected: string[];
+  privateExpected: string[];
+};
+
+const asymmetricVectors: PairVector[] = [
+  {
+    name: 'RSA-OAEP',
+    algorithm: {
+      name: 'RSA-OAEP',
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: 'SHA-256',
+    },
+    usages: [
+      'wrapKey',
+      'unwrapKey',
+      'decrypt',
+      'encrypt',
+      'unwrapKey',
+      'wrapKey',
+      'decrypt',
+      'encrypt',
+    ],
+    publicExpected: ['encrypt', 'wrapKey'],
+    privateExpected: ['decrypt', 'unwrapKey'],
+  },
+  {
+    name: 'RSA-PSS',
+    algorithm: {
+      name: 'RSA-PSS',
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: 'SHA-256',
+    },
+    usages: ['verify', 'sign', 'verify', 'sign'],
+    publicExpected: ['verify'],
+    privateExpected: ['sign'],
+  },
+  {
+    name: 'ECDSA P-256',
+    algorithm: { name: 'ECDSA', namedCurve: 'P-256' },
+    usages: ['verify', 'sign', 'verify', 'sign', 'verify'],
+    publicExpected: ['verify'],
+    privateExpected: ['sign'],
+  },
+  {
+    name: 'ECDH P-256',
+    algorithm: { name: 'ECDH', namedCurve: 'P-256' },
+    usages: ['deriveBits', 'deriveKey', 'deriveBits', 'deriveKey'],
+    publicExpected: [],
+    privateExpected: ['deriveKey', 'deriveBits'],
+  },
+  {
+    name: 'Ed25519',
+    algorithm: { name: 'Ed25519' },
+    usages: ['verify', 'sign', 'verify', 'sign'],
+    publicExpected: ['verify'],
+    privateExpected: ['sign'],
+  },
+  {
+    name: 'X25519',
+    algorithm: { name: 'X25519' },
+    usages: ['deriveBits', 'deriveKey', 'deriveBits', 'deriveKey'],
+    publicExpected: [],
+    privateExpected: ['deriveKey', 'deriveBits'],
+  },
+  {
+    name: 'ML-DSA-65',
+    algorithm: { name: 'ML-DSA-65' },
+    usages: ['verify', 'sign', 'verify', 'sign'],
+    publicExpected: ['verify'],
+    privateExpected: ['sign'],
+  },
+  {
+    name: 'ML-KEM-768',
+    algorithm: { name: 'ML-KEM-768' },
+    usages: [
+      'decapsulateBits',
+      'encapsulateBits',
+      'decapsulateKey',
+      'encapsulateKey',
+      'decapsulateBits',
+      'encapsulateBits',
+    ],
+    publicExpected: ['encapsulateKey', 'encapsulateBits'],
+    privateExpected: ['decapsulateKey', 'decapsulateBits'],
+  },
+];
+
+for (const v of asymmetricVectors) {
+  test(SUITE, `generateKey ${v.name} usages canonical + deduped`, async () => {
+    const { publicKey, privateKey } = (await subtle.generateKey(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      v.algorithm as any,
+      true,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      v.usages as any,
+    )) as WebCryptoKeyPair;
+    expect(publicKey.usages, `${v.name} publicKey`).to.deep.equal(
+      v.publicExpected,
+    );
+    expect(privateKey.usages, `${v.name} privateKey`).to.deep.equal(
+      v.privateExpected,
+    );
+  });
+}
+
+// --- importKey: raw symmetric ---------------------------------------------
+
+test(SUITE, 'importKey raw AES-GCM dedupes + canonicalizes', async () => {
+  const key = await subtle.importKey(
+    'raw',
+    new Uint8Array(16),
+    { name: 'AES-GCM' },
+    true,
+    ['decrypt', 'encrypt', 'decrypt'],
+  );
+  expect(key.usages).to.deep.equal(['encrypt', 'decrypt']);
+});
+
+test(SUITE, 'importKey raw HMAC dedupes + canonicalizes', async () => {
+  const key = await subtle.importKey(
+    'raw',
+    new Uint8Array(32),
+    { name: 'HMAC', hash: 'SHA-256' },
+    true,
+    ['verify', 'sign', 'verify', 'sign'],
+  );
+  expect(key.usages).to.deep.equal(['sign', 'verify']);
+});
+
+// HKDF / PBKDF2 (importGenericSecretKey path).
+for (const name of ['HKDF', 'PBKDF2']) {
+  test(SUITE, `importKey raw ${name} dedupes + canonicalizes`, async () => {
+    const key = await subtle.importKey(
+      'raw',
+      new Uint8Array(16),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      name as any,
+      false,
+      ['deriveBits', 'deriveKey', 'deriveBits', 'deriveKey'],
+    );
+    expect(key.usages).to.deep.equal(['deriveKey', 'deriveBits']);
+  });
+}
+
+// --- importKey: JWK -------------------------------------------------------
+
+test(SUITE, 'importKey jwk AES-CBC dedupes', async () => {
+  const jwk: JWK = {
+    kty: 'oct',
+    k: 'AAAAAAAAAAAAAAAAAAAAAA',
+    alg: 'A128CBC',
+  };
+  const key = await subtle.importKey('jwk', jwk, { name: 'AES-CBC' }, true, [
+    'decrypt',
+    'encrypt',
+    'decrypt',
+  ]);
+  expect(key.usages).to.deep.equal(['encrypt', 'decrypt']);
+});
+
+// --- KeyObject.toCryptoKey() ----------------------------------------------
+
+test(SUITE, 'createSecretKey().toCryptoKey() HMAC dedupes', () => {
+  const keyObject = crypto.createSecretKey(new Uint8Array(32));
+  const key = keyObject.toCryptoKey({ name: 'HMAC', hash: 'SHA-256' }, true, [
+    'verify',
+    'sign',
+    'verify',
+    'sign',
+  ]);
+  expect(key.usages).to.deep.equal(['sign', 'verify']);
+});
+
+test(SUITE, 'createSecretKey().toCryptoKey() AES-GCM dedupes', () => {
+  const keyObject = crypto.createSecretKey(new Uint8Array(16));
+  const key = keyObject.toCryptoKey({ name: 'AES-GCM' }, true, [
+    'decrypt',
+    'encrypt',
+    'decrypt',
+  ]);
+  expect(key.usages).to.deep.equal(['encrypt', 'decrypt']);
+});
+
+// --- JWK export `key_ops` mirrors canonical usages ------------------------
+
+test(SUITE, 'exportKey jwk AES-CTR key_ops canonical', async () => {
+  const key = (await subtle.generateKey(
+    { name: 'AES-CTR', length: 128 },
+    true,
+    ['wrapKey', 'encrypt', 'decrypt', 'encrypt', 'wrapKey', 'unwrapKey'],
+  )) as CryptoKey;
+  const jwk = (await subtle.exportKey('jwk', key)) as JWK;
+  expect(jwk.key_ops).to.deep.equal([
+    'encrypt',
+    'decrypt',
+    'wrapKey',
+    'unwrapKey',
+  ]);
+});
+
+test(SUITE, 'exportKey jwk HMAC key_ops canonical', async () => {
+  const key = (await subtle.generateKey(
+    { name: 'HMAC', hash: 'SHA-256' },
+    true,
+    ['verify', 'sign', 'verify', 'sign'],
+  )) as CryptoKey;
+  const jwk = (await subtle.exportKey('jwk', key)) as JWK;
+  expect(jwk.key_ops).to.deep.equal(['sign', 'verify']);
+});
+
+test(SUITE, 'exportKey jwk RSA-OAEP pair key_ops canonical', async () => {
+  const { publicKey, privateKey } = (await subtle.generateKey(
+    {
+      name: 'RSA-OAEP',
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: 'SHA-256',
+    },
+    true,
+    [
+      'wrapKey',
+      'unwrapKey',
+      'decrypt',
+      'encrypt',
+      'unwrapKey',
+      'wrapKey',
+      'decrypt',
+      'encrypt',
+    ],
+  )) as WebCryptoKeyPair;
+
+  const publicJwk = (await subtle.exportKey('jwk', publicKey)) as JWK;
+  const privateJwk = (await subtle.exportKey('jwk', privateKey)) as JWK;
+  expect(publicJwk.key_ops).to.deep.equal(['encrypt', 'wrapKey']);
+  expect(privateJwk.key_ops).to.deep.equal(['decrypt', 'unwrapKey']);
+});
+
+test(SUITE, 'exportKey jwk ML-KEM-768 pair key_ops canonical', async () => {
+  const { publicKey, privateKey } = (await subtle.generateKey(
+    { name: 'ML-KEM-768' },
+    true,
+    [
+      'decapsulateBits',
+      'encapsulateBits',
+      'decapsulateKey',
+      'encapsulateKey',
+      'decapsulateBits',
+      'encapsulateBits',
+    ],
+  )) as WebCryptoKeyPair;
+
+  const publicJwk = (await subtle.exportKey('jwk', publicKey)) as JWK;
+  const privateJwk = (await subtle.exportKey('jwk', privateKey)) as JWK;
+  expect(publicJwk.key_ops).to.deep.equal([
+    'encapsulateKey',
+    'encapsulateBits',
+  ]);
+  expect(privateJwk.key_ops).to.deep.equal([
+    'decapsulateKey',
+    'decapsulateBits',
+  ]);
+});

--- a/example/src/tests/subtle/usage_canonicalization.ts
+++ b/example/src/tests/subtle/usage_canonicalization.ts
@@ -1,7 +1,10 @@
 import { expect } from 'chai';
 import type {
+  AnyAlgorithm,
   CryptoKey,
   JWK,
+  KeyUsage,
+  SubtleAlgorithm,
   WebCryptoKeyPair,
 } from 'react-native-quick-crypto';
 import crypto, { subtle } from 'react-native-quick-crypto';
@@ -21,10 +24,9 @@ const SUITE = 'subtle.usage-canonicalization';
 
 const symmetricVectors: Array<{
   name: string;
-  // SubtleAlgorithm types vary across algorithms; loose typing is fine here.
-  algorithm: object;
-  usages: string[];
-  expected: string[];
+  algorithm: SubtleAlgorithm;
+  usages: KeyUsage[];
+  expected: KeyUsage[];
 }> = [
   {
     name: 'HMAC',
@@ -62,11 +64,9 @@ const symmetricVectors: Array<{
 for (const { name, algorithm, usages, expected } of symmetricVectors) {
   test(SUITE, `generateKey ${name} usages canonical + deduped`, async () => {
     const key = (await subtle.generateKey(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      algorithm as any,
+      algorithm,
       true,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      usages as any,
+      usages,
     )) as CryptoKey;
     expect(key.usages).to.deep.equal(expected);
     expect(key.usages.length).to.equal(expected.length);
@@ -77,10 +77,10 @@ for (const { name, algorithm, usages, expected } of symmetricVectors) {
 
 type PairVector = {
   name: string;
-  algorithm: object;
-  usages: string[];
-  publicExpected: string[];
-  privateExpected: string[];
+  algorithm: SubtleAlgorithm;
+  usages: KeyUsage[];
+  publicExpected: KeyUsage[];
+  privateExpected: KeyUsage[];
 };
 
 const asymmetricVectors: PairVector[] = [
@@ -171,11 +171,9 @@ const asymmetricVectors: PairVector[] = [
 for (const v of asymmetricVectors) {
   test(SUITE, `generateKey ${v.name} usages canonical + deduped`, async () => {
     const { publicKey, privateKey } = (await subtle.generateKey(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      v.algorithm as any,
+      v.algorithm,
       true,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      v.usages as any,
+      v.usages,
     )) as WebCryptoKeyPair;
     expect(publicKey.usages, `${v.name} publicKey`).to.deep.equal(
       v.publicExpected,
@@ -211,16 +209,15 @@ test(SUITE, 'importKey raw HMAC dedupes + canonicalizes', async () => {
 });
 
 // HKDF / PBKDF2 (importGenericSecretKey path).
-for (const name of ['HKDF', 'PBKDF2']) {
+const derivationAlgs: AnyAlgorithm[] = ['HKDF', 'PBKDF2'];
+for (const name of derivationAlgs) {
   test(SUITE, `importKey raw ${name} dedupes + canonicalizes`, async () => {
-    const key = await subtle.importKey(
-      'raw',
-      new Uint8Array(16),
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      name as any,
-      false,
-      ['deriveBits', 'deriveKey', 'deriveBits', 'deriveKey'],
-    );
+    const key = await subtle.importKey('raw', new Uint8Array(16), name, false, [
+      'deriveBits',
+      'deriveKey',
+      'deriveBits',
+      'deriveKey',
+    ]);
     expect(key.usages).to.deep.equal(['deriveKey', 'deriveBits']);
   });
 }
@@ -240,6 +237,39 @@ test(SUITE, 'importKey jwk AES-CBC dedupes', async () => {
   ]);
   expect(key.usages).to.deep.equal(['encrypt', 'decrypt']);
 });
+
+// --- key.usages immutability ----------------------------------------------
+
+test(
+  SUITE,
+  'key.usages is frozen (push throws, length unchanged)',
+  async () => {
+    const key = (await subtle.generateKey(
+      { name: 'AES-GCM', length: 128 },
+      true,
+      ['encrypt', 'decrypt'],
+    )) as CryptoKey;
+    expect(Object.isFrozen(key.usages)).to.equal(true);
+    expect(() => key.usages.push('sign')).to.throw(TypeError);
+    expect(key.usages).to.deep.equal(['encrypt', 'decrypt']);
+  },
+);
+
+test(
+  SUITE,
+  'jwk.key_ops is independent of key.usages (mutable copy)',
+  async () => {
+    const key = (await subtle.generateKey(
+      { name: 'AES-GCM', length: 128 },
+      true,
+      ['encrypt', 'decrypt'],
+    )) as CryptoKey;
+    const jwk = (await subtle.exportKey('jwk', key)) as JWK;
+    expect(jwk.key_ops).to.deep.equal(['encrypt', 'decrypt']);
+    jwk.key_ops!.push('sign');
+    expect(key.usages).to.deep.equal(['encrypt', 'decrypt']);
+  },
+);
 
 // --- KeyObject.toCryptoKey() ----------------------------------------------
 

--- a/packages/react-native-quick-crypto/src/keys/classes.ts
+++ b/packages/react-native-quick-crypto/src/keys/classes.ts
@@ -30,7 +30,8 @@ export class CryptoKey {
   ) {
     this.keyObject = keyObject;
     this.keyAlgorithm = keyAlgorithm;
-    this.keyUsages = getSortedUsages(keyUsages);
+    // Frozen so external code can't mutate `key.usages` (per WebCrypto spec).
+    this.keyUsages = Object.freeze(getSortedUsages(keyUsages)) as KeyUsage[];
     this.keyExtractable = keyExtractable;
   }
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/react-native-quick-crypto/src/keys/classes.ts
+++ b/packages/react-native-quick-crypto/src/keys/classes.ts
@@ -9,7 +9,7 @@ import type {
   KeyUsage,
   SubtleAlgorithm,
 } from '../utils';
-import { KeyType, KFormatType, KeyEncoding } from '../utils';
+import { KeyType, KFormatType, KeyEncoding, getSortedUsages } from '../utils';
 import { parsePrivateKeyEncoding, parsePublicKeyEncoding } from './utils';
 
 export class CryptoKey {
@@ -30,7 +30,7 @@ export class CryptoKey {
   ) {
     this.keyObject = keyObject;
     this.keyAlgorithm = keyAlgorithm;
-    this.keyUsages = keyUsages;
+    this.keyUsages = getSortedUsages(keyUsages);
     this.keyExtractable = keyExtractable;
   }
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/react-native-quick-crypto/src/subtle.ts
+++ b/packages/react-native-quick-crypto/src/subtle.ts
@@ -1688,7 +1688,7 @@ const exportKeyRaw = (key: CryptoKey): ArrayBuffer | unknown => {
 const exportKeyJWK = (key: CryptoKey): ArrayBuffer | unknown => {
   const jwk = key.keyObject.handle.exportJwk(
     {
-      key_ops: key.usages,
+      key_ops: [...key.usages],
       ext: key.extractable,
     },
     true,

--- a/packages/react-native-quick-crypto/src/utils/validation.ts
+++ b/packages/react-native-quick-crypto/src/utils/validation.ts
@@ -67,6 +67,27 @@ export const getUsagesUnion = (usageSet: KeyUsage[], ...usages: KeyUsage[]) => {
   return newset;
 };
 
+const kCanonicalUsageOrder: readonly KeyUsage[] = [
+  'encrypt',
+  'decrypt',
+  'sign',
+  'verify',
+  'deriveKey',
+  'deriveBits',
+  'wrapKey',
+  'unwrapKey',
+  'encapsulateKey',
+  'encapsulateBits',
+  'decapsulateKey',
+  'decapsulateBits',
+];
+
+export function getSortedUsages(usages: KeyUsage[]): KeyUsage[] {
+  if (usages.length <= 1) return usages.slice();
+  const set = new Set<KeyUsage>(usages);
+  return kCanonicalUsageOrder.filter(u => set.has(u));
+}
+
 const kKeyOps: {
   [key in KeyUsage]: number;
 } = {

--- a/packages/react-native-quick-crypto/src/utils/validation.ts
+++ b/packages/react-native-quick-crypto/src/utils/validation.ts
@@ -57,6 +57,9 @@ export const validateMaxBufferLength = (
   }
 };
 
+// Returns the intersection of `usageSet` and the spread `usages`, preserving
+// the spread order. Dedup and canonical ordering are not performed here —
+// the `CryptoKey` constructor runs `getSortedUsages` on every input.
 export const getUsagesUnion = (usageSet: KeyUsage[], ...usages: KeyUsage[]) => {
   const newset: KeyUsage[] = [];
   for (let n = 0; n < usages.length; n++) {
@@ -83,9 +86,8 @@ const kCanonicalUsageOrder: readonly KeyUsage[] = [
 ];
 
 export function getSortedUsages(usages: KeyUsage[]): KeyUsage[] {
-  if (usages.length <= 1) return usages.slice();
   const set = new Set<KeyUsage>(usages);
-  return kCanonicalUsageOrder.filter(u => set.has(u));
+  return kCanonicalUsageOrder.filter(usage => set.has(usage));
 }
 
 const kKeyOps: {


### PR DESCRIPTION
Closes #1000 (tracked in #995).

## Summary

WebCrypto requires `CryptoKey.usages` to be deduplicated and returned in a canonical order:

```
encrypt, decrypt, sign, verify, deriveKey, deriveBits,
wrapKey, unwrapKey, encapsulateKey, encapsulateBits,
decapsulateKey, decapsulateBits
```

RNQC's `CryptoKey` constructor previously stored the input array verbatim — no dedup, no reorder. Tests using `includes()` worked, but tests asserting array equality or comparing JWK `key_ops` order (and interop with Node-generated keys) would fail.

Reference: Node commit `fe7ebccd0ce` (`crypto: deduplicate and canonicalize CryptoKey usages`), `lib/internal/crypto/util.js:731-755`.

## Changes

- New `getSortedUsages` helper in `utils/validation.ts` that dedupes and reorders a `KeyUsage[]` per the canonical order.
- Applied in the `CryptoKey` constructor — the single choke point every `subtle.generateKey`, `subtle.importKey`, and `KeyObject#toCryptoKey` path flows through.
- JWK exports populate `jwk.key_ops` from `key.usages`, so they pick up the canonical order automatically (no separate change needed).

## Test plan

New `subtle.usage-canonicalization` suite (~30 tests):

- `generateKey` — HMAC, AES-CTR/CBC/GCM (symmetric); RSA-OAEP, RSA-PSS, ECDSA, ECDH, Ed25519, X25519, ML-DSA-65, ML-KEM-768 (key pairs).
- `importKey` raw — AES-GCM, HMAC, HKDF, PBKDF2 (exercises the generic-secret import path).
- `importKey` jwk — AES-CBC.
- `KeyObject#toCryptoKey` — HMAC, AES-GCM via `createSecretKey`.
- JWK export `key_ops` — AES-CTR, HMAC, RSA-OAEP pair, ML-KEM-768 pair — confirms canonical order propagates from `key.usages` to `jwk.key_ops`.

- [ ] Tests pass in the example app on iOS
- [ ] Tests pass in the example app on Android
- [ ] No regression in existing WebCrypto / key suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)