### PR TITLE
fix: validate JWK alg/crv/kty per algorithm in subtle.importKey

### DIFF
--- a/example/src/tests/subtle/import_export.ts
+++ b/example/src/tests/subtle/import_export.ts
@@ -3025,7 +3025,7 @@ for (const { name } of edCurves) {
     expect(imported.algorithm.name).to.equal(name);
   });
 
-  test(SUITE, `${name} importKey rejects jwk use="enc"`, async () => {
+  test(SUITE, `${name} importKey rejects wrong jwk kty`, async () => {
     const keyPair = (await subtle.generateKey({ name }, true, [
       'sign',
       'verify',
@@ -3036,10 +3036,36 @@ for (const { name } of edCurves) {
     )) as JWK;
     await assertThrowsAsync(
       async () =>
-        await subtle.importKey('jwk', { ...jwk, use: 'enc' }, { name }, true, [
+        await subtle.importKey('jwk', { ...jwk, kty: 'EC' }, { name }, true, [
           'verify',
         ]),
-      'Invalid JWK "use" Parameter',
+      'Invalid JWK "kty" Parameter',
+    );
+  });
+}
+
+const xCurves = ['X25519', 'X448'] as const;
+for (const name of xCurves) {
+  test(SUITE, `${name} importKey rejects wrong jwk crv`, async () => {
+    const keyPair = (await subtle.generateKey({ name }, true, [
+      'deriveKey',
+      'deriveBits',
+    ])) as CryptoKeyPair;
+    const jwk = (await subtle.exportKey(
+      'jwk',
+      keyPair.publicKey as CryptoKey,
+    )) as JWK;
+    const wrongCrv = name === 'X25519' ? 'X448' : 'X25519';
+    await assertThrowsAsync(
+      async () =>
+        await subtle.importKey(
+          'jwk',
+          { ...jwk, crv: wrongCrv },
+          { name },
+          true,
+          [],
+        ),
+      'JWK "crv" Parameter and algorithm name mismatch',
     );
   });
 }

--- a/example/src/tests/subtle/import_export.ts
+++ b/example/src/tests/subtle/import_export.ts
@@ -2898,6 +2898,152 @@ for (const { name: curveName, rawSize } of edCurves) {
   });
 }
 
+// --- JWK validation: per-algorithm alg/crv/use mismatch (gh#1001) ---
+
+const RSA_JWK_ALG_CASES: {
+  name: RSAKeyPairAlgorithm;
+  hash: HashAlgorithm;
+  expected: string;
+  wrong: string;
+  usages: KeyUsage[];
+}[] = [
+  {
+    name: 'RSASSA-PKCS1-v1_5',
+    hash: 'SHA-256',
+    expected: 'RS256',
+    wrong: 'RS384',
+    usages: ['verify'],
+  },
+  {
+    name: 'RSA-PSS',
+    hash: 'SHA-256',
+    expected: 'PS256',
+    wrong: 'PS384',
+    usages: ['verify'],
+  },
+  {
+    name: 'RSA-OAEP',
+    hash: 'SHA-256',
+    expected: 'RSA-OAEP-256',
+    wrong: 'RSA-OAEP-384',
+    usages: ['encrypt'],
+  },
+];
+
+for (const { name, hash, wrong, usages } of RSA_JWK_ALG_CASES) {
+  test(SUITE, `${name}/${hash} importKey rejects wrong jwk alg`, async () => {
+    const keyPair = (await subtle.generateKey(
+      {
+        name,
+        modulusLength: 2048,
+        publicExponent: new Uint8Array([1, 0, 1]),
+        hash,
+      },
+      true,
+      name === 'RSA-OAEP' ? ['encrypt', 'decrypt'] : ['sign', 'verify'],
+    )) as CryptoKeyPair;
+    const jwk = (await subtle.exportKey(
+      'jwk',
+      keyPair.publicKey as CryptoKey,
+    )) as JWK;
+    await assertThrowsAsync(
+      async () =>
+        await subtle.importKey(
+          'jwk',
+          { ...jwk, alg: wrong },
+          { name, hash },
+          true,
+          usages,
+        ),
+      'JWK "alg" does not match the requested algorithm',
+    );
+  });
+}
+
+for (const { name } of edCurves) {
+  test(SUITE, `${name} importKey rejects wrong jwk crv`, async () => {
+    const keyPair = (await subtle.generateKey({ name }, true, [
+      'sign',
+      'verify',
+    ])) as CryptoKeyPair;
+    const jwk = (await subtle.exportKey(
+      'jwk',
+      keyPair.publicKey as CryptoKey,
+    )) as JWK;
+    const wrongCrv = name === 'Ed25519' ? 'Ed448' : 'Ed25519';
+    await assertThrowsAsync(
+      async () =>
+        await subtle.importKey(
+          'jwk',
+          { ...jwk, crv: wrongCrv },
+          { name },
+          true,
+          ['verify'],
+        ),
+      'JWK "crv" Parameter and algorithm name mismatch',
+    );
+  });
+
+  test(SUITE, `${name} importKey rejects wrong jwk alg`, async () => {
+    const keyPair = (await subtle.generateKey({ name }, true, [
+      'sign',
+      'verify',
+    ])) as CryptoKeyPair;
+    const jwk = (await subtle.exportKey(
+      'jwk',
+      keyPair.publicKey as CryptoKey,
+    )) as JWK;
+    await assertThrowsAsync(
+      async () =>
+        await subtle.importKey(
+          'jwk',
+          { ...jwk, alg: 'RS256' },
+          { name },
+          true,
+          ['verify'],
+        ),
+      'JWK "alg" does not match the requested algorithm',
+    );
+  });
+
+  test(SUITE, `${name} importKey accepts jwk alg "EdDSA"`, async () => {
+    const keyPair = (await subtle.generateKey({ name }, true, [
+      'sign',
+      'verify',
+    ])) as CryptoKeyPair;
+    const jwk = (await subtle.exportKey(
+      'jwk',
+      keyPair.publicKey as CryptoKey,
+    )) as JWK;
+    const imported = await subtle.importKey(
+      'jwk',
+      { ...jwk, alg: 'EdDSA' },
+      { name },
+      true,
+      ['verify'],
+    );
+    expect(imported.algorithm.name).to.equal(name);
+  });
+
+  test(SUITE, `${name} importKey rejects jwk use="enc"`, async () => {
+    const keyPair = (await subtle.generateKey({ name }, true, [
+      'sign',
+      'verify',
+    ])) as CryptoKeyPair;
+    const jwk = (await subtle.exportKey(
+      'jwk',
+      keyPair.publicKey as CryptoKey,
+    )) as JWK;
+    await assertThrowsAsync(
+      async () =>
+        await subtle.importKey('jwk', { ...jwk, use: 'enc' }, { name }, true, [
+          'verify',
+        ]),
+      'Invalid JWK "use" Parameter',
+    );
+  });
+}
+
 // AES-OCB JWK export/import roundtrip
 test(SUITE, 'AES-OCB export/import jwk', async () => {
   const key = await subtle.generateKey({ name: 'AES-OCB', length: 256 }, true, [

--- a/packages/react-native-quick-crypto/src/subtle.ts
+++ b/packages/react-native-quick-crypto/src/subtle.ts
@@ -958,12 +958,17 @@ function rsaImportKey(
     checkUsages();
 
     if (jwk.alg !== undefined) {
-      const jwkContext =
-        name === 'RSASSA-PKCS1-v1_5'
-          ? HashContext.JwkRsa
-          : name === 'RSA-PSS'
-            ? HashContext.JwkRsaPss
-            : HashContext.JwkRsaOaep;
+      let jwkContext: HashContext;
+      switch (name) {
+        case 'RSASSA-PKCS1-v1_5':
+          jwkContext = HashContext.JwkRsa;
+          break;
+        case 'RSA-PSS':
+          jwkContext = HashContext.JwkRsaPss;
+          break;
+        default:
+          jwkContext = HashContext.JwkRsaOaep;
+      }
       const expectedAlg = normalizeHashName(algorithm.hash, jwkContext);
       if (jwk.alg !== expectedAlg) {
         throw lazyDOMException(
@@ -1261,6 +1266,9 @@ function edImportKey(
     const jwkData = data as JWK;
     if (!jwkData || typeof jwkData !== 'object') {
       throw lazyDOMException('Invalid keyData', 'DataError');
+    }
+    if (jwkData.kty !== 'OKP') {
+      throw lazyDOMException('Invalid JWK "kty" Parameter', 'DataError');
     }
     const expectedUse = isX ? 'enc' : 'sig';
     validateJwkStructure(jwkData, extractable, keyUsages, expectedUse);

--- a/packages/react-native-quick-crypto/src/subtle.ts
+++ b/packages/react-native-quick-crypto/src/subtle.ts
@@ -957,6 +957,22 @@ function rsaImportKey(
     validateJwkStructure(jwk, extractable, keyUsages, expectedUse);
     checkUsages();
 
+    if (jwk.alg !== undefined) {
+      const jwkContext =
+        name === 'RSASSA-PKCS1-v1_5'
+          ? HashContext.JwkRsa
+          : name === 'RSA-PSS'
+            ? HashContext.JwkRsaPss
+            : HashContext.JwkRsaOaep;
+      const expectedAlg = normalizeHashName(algorithm.hash, jwkContext);
+      if (jwk.alg !== expectedAlg) {
+        throw lazyDOMException(
+          'JWK "alg" does not match the requested algorithm',
+          'DataError',
+        );
+      }
+    }
+
     const handle =
       NitroModules.createHybridObject<KeyObjectHandle>('KeyObjectHandle');
     let keyType: KeyType | undefined;
@@ -1248,6 +1264,23 @@ function edImportKey(
     }
     const expectedUse = isX ? 'enc' : 'sig';
     validateJwkStructure(jwkData, extractable, keyUsages, expectedUse);
+
+    if (jwkData.crv !== name) {
+      throw lazyDOMException(
+        'JWK "crv" Parameter and algorithm name mismatch',
+        'DataError',
+      );
+    }
+
+    if (!isX && jwkData.alg !== undefined) {
+      if (jwkData.alg !== name && jwkData.alg !== 'EdDSA') {
+        throw lazyDOMException(
+          'JWK "alg" does not match the requested algorithm',
+          'DataError',
+        );
+      }
+    }
+
     checkUsages();
     const handle =
       NitroModules.createHybridObject<KeyObjectHandle>('KeyObjectHandle');


### PR DESCRIPTION
## Summary

Tightens JWK validation in `subtle.importKey` for RSA and CFRG algorithms so that mismatched `alg`, `crv`, or `kty` parameters are rejected at the JS layer with a `DataError` DOMException, matching Node.js's WebCrypto behavior.

Previously, mismatched JWK parameters either passed through to the C++ layer (yielding opaque errors) or were silently accepted.

## Changes

- **RSA** (`RSASSA-PKCS1-v1_5`, `RSA-PSS`, `RSA-OAEP`): when `jwk.alg` is set, verify it matches the algorithm + hash combination (e.g. RSA-PSS + SHA-256 → `PS256`).
- **CFRG** (`Ed25519`, `Ed448`, `X25519`, `X448`): verify `jwk.kty === 'OKP'` and `jwk.crv === algorithm.name`. For Ed curves, if `jwk.alg` is set it must equal the algorithm name or `'EdDSA'`.
- Error messages mirror Node verbatim (`'JWK "alg" does not match the requested algorithm'`, `'JWK "crv" Parameter and algorithm name mismatch'`, `'Invalid JWK "kty" Parameter'`) for downstream parity.
- Tests added covering RSA wrong-alg, Ed wrong-crv/wrong-alg/`'EdDSA'`-accepted/wrong-kty, and X25519/X448 wrong-crv.

## Test plan

- [ ] RSA importKey rejects mismatched `alg` for each of RSASSA-PKCS1-v1_5, RSA-PSS, RSA-OAEP
- [ ] Ed25519/Ed448 importKey rejects mismatched `crv`, mismatched `alg`, and wrong `kty`
- [ ] Ed25519/Ed448 importKey accepts `alg: 'EdDSA'`
- [ ] X25519/X448 importKey rejects mismatched `crv`
- [ ] Existing JWK roundtrip tests still pass

Fixes #1001