### PR TITLE
fix: default RSA-PSS saltLength to RSA_PSS_SALTLEN_MAX_SIGN

### DIFF
--- a/example/src/tests/keys/sign_verify_oneshot.ts
+++ b/example/src/tests/keys/sign_verify_oneshot.ts
@@ -113,6 +113,38 @@ test(SUITE, 'RSA-PSS with padding and salt length options', () => {
   expect(isValid).to.equal(true);
 });
 
+test(SUITE, 'RSA-PSS defaults saltLength to MAX_SIGN when undefined', () => {
+  const signature = sign('SHA256', testData, {
+    key: rsaPrivateKeyPem,
+    padding: constants.RSA_PKCS1_PSS_PADDING,
+  });
+
+  const isValid = verify(
+    'SHA256',
+    testData,
+    {
+      key: rsaPublicKeyPem,
+      padding: constants.RSA_PKCS1_PSS_PADDING,
+    },
+    signature,
+  );
+
+  expect(isValid).to.equal(true);
+
+  const isValidExplicit = verify(
+    'SHA256',
+    testData,
+    {
+      key: rsaPublicKeyPem,
+      padding: constants.RSA_PKCS1_PSS_PADDING,
+      saltLength: constants.RSA_PSS_SALTLEN_MAX_SIGN,
+    },
+    signature,
+  );
+
+  expect(isValidExplicit).to.equal(true);
+});
+
 // --- ECDSA Tests ---
 
 test(SUITE, 'ECDSA P-256 with DER encoding', async () => {

--- a/example/src/tests/keys/sign_verify_streaming.ts
+++ b/example/src/tests/keys/sign_verify_streaming.ts
@@ -219,6 +219,40 @@ test(SUITE, 'RSA-PSS with SHA256 and auto salt length', () => {
   expect(isValid).to.equal(true);
 });
 
+test(SUITE, 'RSA-PSS defaults saltLength to MAX_SIGN when undefined', () => {
+  const signer = createSign('SHA256');
+  signer.update(testData);
+  const signature = signer.sign({
+    key: rsaPrivateKeyPem,
+    padding: constants.RSA_PKCS1_PSS_PADDING,
+  });
+
+  const verifier = createVerify('SHA256');
+  verifier.update(testData);
+  const isValid = verifier.verify(
+    {
+      key: rsaPublicKeyPem,
+      padding: constants.RSA_PKCS1_PSS_PADDING,
+    },
+    signature,
+  );
+
+  expect(isValid).to.equal(true);
+
+  const verifierExplicit = createVerify('SHA256');
+  verifierExplicit.update(testData);
+  const isValidExplicit = verifierExplicit.verify(
+    {
+      key: rsaPublicKeyPem,
+      padding: constants.RSA_PKCS1_PSS_PADDING,
+      saltLength: constants.RSA_PSS_SALTLEN_MAX_SIGN,
+    },
+    signature,
+  );
+
+  expect(isValidExplicit).to.equal(true);
+});
+
 // --- KeyObject Tests ---
 
 test(SUITE, 'Sign/Verify with KeyObject', () => {

--- a/packages/react-native-quick-crypto/src/keys/signVerify.ts
+++ b/packages/react-native-quick-crypto/src/keys/signVerify.ts
@@ -13,6 +13,7 @@ import {
   KFormatType,
   KeyEncoding,
 } from '../utils';
+import { constants } from '../constants';
 
 type KeyInput = BinaryLike | KeyObject | CryptoKey | KeyInputObject;
 
@@ -144,6 +145,16 @@ function dsaEncodingToNumber(
   return undefined;
 }
 
+function getSaltLength(options?: SignOptions): number | undefined {
+  if (
+    options?.padding === constants.RSA_PKCS1_PSS_PADDING &&
+    options?.saltLength === undefined
+  ) {
+    return constants.RSA_PSS_SALTLEN_MAX_SIGN;
+  }
+  return options?.saltLength;
+}
+
 export class Sign {
   private handle: SignHandleSpec;
 
@@ -169,7 +180,7 @@ export class Sign {
     const signature = this.handle.sign(
       keyObject.handle,
       options?.padding,
-      options?.saltLength,
+      getSaltLength(options),
       dsaEncodingToNumber(options?.dsaEncoding),
     );
 
@@ -219,7 +230,7 @@ export class Verify {
       keyObject.handle,
       sigBuffer,
       options?.padding,
-      options?.saltLength,
+      getSaltLength(options),
       dsaEncodingToNumber(options?.dsaEncoding),
     );
   }


### PR DESCRIPTION
## Summary

When `padding: RSA_PKCS1_PSS_PADDING` is set on `sign`/`verify` but `saltLength` is omitted, RNQC was passing `undefined` straight through to OpenSSL — which falls back to digest length (-1). Node.js defaults this case to `RSA_PSS_SALTLEN_MAX_SIGN` (-2), so signatures produced by RNQC were not interoperable with Node's defaults.

This PR mirrors Node's behavior in `lib/internal/crypto/sig.js` (`getSaltLength`): when `padding === RSA_PKCS1_PSS_PADDING` and `saltLength === undefined`, default to `RSA_PSS_SALTLEN_MAX_SIGN`. Behavior is unchanged when `saltLength` is set explicitly.

## Changes

- `packages/react-native-quick-crypto/src/keys/signVerify.ts`: add `getSaltLength()` helper applying the Node.js default; wire it into `Sign.sign` and `Verify.verify`.
- `example/src/tests/keys/sign_verify_oneshot.ts`: new test verifying that an unspecified-salt sign round-trips and matches an explicit `RSA_PSS_SALTLEN_MAX_SIGN` verify.
- `example/src/tests/keys/sign_verify_streaming.ts`: same coverage for the streaming `createSign` / `createVerify` API.

## Testing

- [ ] Run example app — new tests `RSA-PSS defaults saltLength to MAX_SIGN when undefined` pass in both `keys.sign/verify` suites.
- [ ] Existing RSA-PSS tests with explicit `saltLength` still pass (no regression).
- [ ] Cross-check: signature produced by RNQC with default saltLength can be verified by Node.js with default options, and vice versa.

Fixes #1006