### PR TITLE
chore: upgrade minimum ios deployment target

### DIFF
--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -38,7 +38,7 @@ target 'QuickCryptoExample' do
     # https://github.com/mrousavy/nitro/issues/422#issuecomment-2545988256
     installer.pods_project.targets.each do |target|
       target.build_configurations.each do |config|
-        config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '16.1'
+        config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '16.4'
         config.build_settings['CLANG_CXX_LANGUAGE_STANDARD'] = 'c++20'
 
         # Force C++20 for all targets, especially problematic ones

--- a/example/ios/QuickCryptoExample.xcodeproj/project.pbxproj
+++ b/example/ios/QuickCryptoExample.xcodeproj/project.pbxproj
@@ -267,7 +267,7 @@
 				DEVELOPMENT_TEAM = 64977D8TY3;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = QuickCryptoExample/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -295,7 +295,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 64977D8TY3;
 				INFOPLIST_FILE = QuickCryptoExample/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -375,7 +375,7 @@
 					"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers",
 					"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers/react/renderer/graphics/platform/ios",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
 				LD = "";
 				LDPLUSPLUS = "";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -461,7 +461,7 @@
 					"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers",
 					"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers/react/renderer/graphics/platform/ios",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
 				LD = "";
 				LDPLUSPLUS = "";
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/packages/react-native-quick-crypto/src/expo-plugin/withXCode.ts
+++ b/packages/react-native-quick-crypto/src/expo-plugin/withXCode.ts
@@ -12,8 +12,8 @@ import path from 'path';
  */
 export const withXCode: ConfigPlugin<ConfigProps> = config => {
   // Use expo-build-properties to bump iOS deployment target
-  config = withBuildProperties(config, { ios: { deploymentTarget: '16.1' } });
-  // Patch the generated Podfile fallback to ensure platform is always 16.1
+  config = withBuildProperties(config, { ios: { deploymentTarget: '16.4' } });
+  // Patch the generated Podfile fallback to ensure platform is always 16.4
   config = withDangerousMod(config, [
     'ios',
     modConfig => {
@@ -40,7 +40,7 @@ export const withXCode: ConfigPlugin<ConfigProps> = config => {
     # https://github.com/mrousavy/nitro/issues/422#issuecomment-2545988256
     installer.pods_project.targets.each do |target|
       target.build_configurations.each do |config|
-        config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '16.1'
+        config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '16.4'
       end
     end
 $2`,


### PR DESCRIPTION
To prepare for expo sdk 56 https://expo.dev/changelog/sdk-56-beta#upgrade-an-existing-project
we need to upgrade minimum ios deployment to 16.4