### PR TITLE
 feat(perf): Speed up direct copy path for decodeUtf16Le()

### DIFF
--- a/packages/react-native-quick-crypto/cpp/utils/HybridUtils.cpp
+++ b/packages/react-native-quick-crypto/cpp/utils/HybridUtils.cpp
@@ -144,10 +144,10 @@ namespace {
         size_t offset = result.size();
         result.reserve(offset + (num * 2)); // Allocate buffer conservatively
 
-        auto* dst = result.data() + offset;
         if (isAscii) {
           // Widen ASCII characters from char into char16_t
           result.resize(offset + (num * 2)); // This fills the buffer with '\0'
+          auto* dst = result.data() + offset;
           const auto* asciiSrc = reinterpret_cast<const char*>(data);
           for (size_t i = 0; i < num; i++, dst += 2) {
             *dst = asciiSrc[i];
@@ -165,6 +165,7 @@ namespace {
         // Slow path for unexpected endianness/char16_t size
         result.resize(offset + (num * 2));
         const auto* utf16Src = reinterpret_cast<const char16_t*>(data);
+        auto* dst = result.data() + offset;
         for (size_t i = 0; i < num; i++) {
           const uint16_t codeUnit = static_cast<uint16_t>(utf16Src[i]);
           dst[i * 2 + 0] = static_cast<uint8_t>(codeUnit & 0xFFu);

--- a/packages/react-native-quick-crypto/cpp/utils/HybridUtils.cpp
+++ b/packages/react-native-quick-crypto/cpp/utils/HybridUtils.cpp
@@ -142,11 +142,12 @@ namespace {
         }
 
         size_t offset = result.size();
-        result.resize(offset + (num * 2)); // This fills the buffer with '\0'
+        result.reserve(offset + (num * 2)); // Allocate buffer conservatively
 
         auto* dst = result.data() + offset;
         if (isAscii) {
           // Widen ASCII characters from char into char16_t
+          result.resize(offset + (num * 2)); // This fills the buffer with '\0'
           const auto* asciiSrc = reinterpret_cast<const char*>(data);
           for (size_t i = 0; i < num; i++, dst += 2) {
             *dst = asciiSrc[i];
@@ -155,13 +156,15 @@ namespace {
           return;
         }
 
-        const auto* utf16Src = reinterpret_cast<const char16_t*>(data);
         if constexpr (kCanDirectCopyUtf16) {
           // Fast&direct copy path
-          std::memcpy(dst, utf16Src, num * 2);
+          const auto* byteSrc = reinterpret_cast<const uint8_t*>(data);
+          result.insert(result.end(), byteSrc, byteSrc + num * 2);
           return;
         }
         // Slow path for unexpected endianness/char16_t size
+        result.resize(offset + (num * 2));
+        const auto* utf16Src = reinterpret_cast<const char16_t*>(data);
         for (size_t i = 0; i < num; i++) {
           const uint16_t codeUnit = static_cast<uint16_t>(utf16Src[i]);
           dst[i * 2 + 0] = static_cast<uint8_t>(codeUnit & 0xFFu);


### PR DESCRIPTION
Inspired by https://github.com/margelo/react-native-quick-crypto/pull/1037#discussion_r3227191197
Remove the implicit zero-filling caused by `vector::resize()` in the direct copy path, increased the speed by 37%

---

<details><summary>Screenshots</summary>

| Before | After |
|---|---|
| <img width="1080" height="2130" alt="image" src="https://github.com/user-attachments/assets/c8752f70-d0d1-476b-ac46-c2e393eedfe4" /> | <img width="1080" height="2136" alt="image" src="https://github.com/user-attachments/assets/aa4b1ccb-2187-4e25-a084-3a05da06d6f8" /> | 

</details>