### PR TITLE
Replaced "react-native-quick-base64": ">=2.1.0" with "^2.1.0", to avoid breaking changes.

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -115,7 +115,7 @@
         "react": "*",
         "react-native": "*",
         "react-native-nitro-modules": ">=0.31.2",
-        "react-native-quick-base64": ">=2.1.0",
+        "react-native-quick-base64": "^2.1.0",
       },
       "optionalPeers": [
         "expo",

--- a/packages/react-native-quick-crypto/package.json
+++ b/packages/react-native-quick-crypto/package.json
@@ -131,7 +131,7 @@
     "react": "*",
     "react-native": "*",
     "react-native-nitro-modules": ">=0.31.2",
-    "react-native-quick-base64": ">=2.1.0",
+    "react-native-quick-base64": "^2.1.0",
     "expo": ">=48.0.0",
     "expo-build-properties": "*"
   },


### PR DESCRIPTION
On versions 3.0.0+ of "react-native-quick-base64" the install() method has been removed, introducing breaking changes for people installing the package via npm install.