### PR TITLE
chore(deps): bump Android OpenSSL 3.6.2-1 and libsodium 1.0.22

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2841,7 +2841,7 @@ SPEC CHECKSUMS:
   NitroMmkv: afbc5b2fbf963be567c6c545aa1efcf6a9cec68e
   NitroModules: 11bba9d065af151eae51e38a6425e04c3b223ff3
   OpenSSL-Universal: 9110d21982bb7e8b22a962b6db56a8aa805afde7
-  QuickCrypto: b6fed48151d7fef2b33e8420c660dde2b421c396
+  QuickCrypto: 5294516c651e33d452090e344da1ea839c4986f1
   RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
   RCTDeprecation: c4b9e2fd0ab200e3af72b013ed6113187c607077
   RCTRequired: e97dd5dafc1db8094e63bc5031e0371f092ae92a

--- a/packages/react-native-quick-crypto/QuickCrypto.podspec
+++ b/packages/react-native-quick-crypto/QuickCrypto.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
   # Ensure libsodium source is present during podspec evaluation when enabled.
   # This is necessary because prepare_command is skipped for :path pods.
   if sodium_enabled
-    sodium_version = "1.0.20"
+    sodium_version = "1.0.22"
     sodium_dir = File.join(__dir__, "ios", "libsodium-stable")
     sodium_header = File.join(sodium_dir, "src", "libsodium", "include", "sodium.h")
     unless File.exist?(sodium_header)
@@ -52,7 +52,7 @@ Pod::Spec.new do |s|
       rm -f OpenSSL.xcframework.zip
       # Build libsodium
       mkdir -p ios
-      curl -L -o ios/libsodium.tar.gz https://download.libsodium.org/libsodium/releases/libsodium-1.0.20-stable.tar.gz
+      curl -L -o ios/libsodium.tar.gz https://download.libsodium.org/libsodium/releases/libsodium-1.0.22-stable.tar.gz
       tar -xzf ios/libsodium.tar.gz -C ios
       cd ios/libsodium-stable
       ./configure --disable-shared --enable-static

--- a/packages/react-native-quick-crypto/android/build.gradle
+++ b/packages/react-native-quick-crypto/android/build.gradle
@@ -154,7 +154,7 @@ dependencies {
 
   if (sodiumEnabled) {
     // Add a dependency on libsodium
-    implementation 'io.github.ronickg:sodium:1.0.20-1'
+    implementation 'io.github.ronickg:sodium:1.0.22-1'
   }
 }
 

--- a/packages/react-native-quick-crypto/android/build.gradle
+++ b/packages/react-native-quick-crypto/android/build.gradle
@@ -150,7 +150,7 @@ dependencies {
   implementation project(":react-native-nitro-modules")
 
   // Add a dependency on OpenSSL
-  implementation 'io.github.ronickg:openssl:3.6.0-1'
+  implementation 'io.github.ronickg:openssl:3.6.2-1'
 
   if (sodiumEnabled) {
     // Add a dependency on libsodium


### PR DESCRIPTION
## Summary

Two related dependency bumps to clear scanner advisories and reduce iOS/Android version drift.

## Changes

- **Android OpenSSL prefab**: `io.github.ronickg:openssl:3.6.0-1` → `3.6.2-1` (skipped 3.6.1; took the latest published prefab). Clears CVE-2025-15467 (CMS EnvelopedData stack overflow — not reachable from RNQC).
- **libsodium**: `1.0.20` → `1.0.22` for both iOS (`QuickCrypto.podspec` download URL + `sodium_version`) and Android (`io.github.ronickg:sodium:1.0.22-1`). Clears CVE-2025-69277 / CVE-2025-15444 from consumer scanners; RNQC isn't actually vulnerable since the Ed25519 path goes through OpenSSL `EVP_PKEY_*`, not libsodium.
- **Podfile.lock**: QuickCrypto pod checksum rev for the podspec change.

iOS OpenSSL needs no podspec change — `OpenSSL-Universal ~> 3.6` auto-resolves to the latest 3.6.x cocoapod.

## Test plan

- [x] Local iOS build succeeded
- [ ] E2E iOS workflow green
- [ ] E2E Android workflow green
- [ ] `SODIUM_ENABLED=1` iOS + Android: XSalsa20 / XSalsa20-Poly1305 / XChaCha20-Poly1305 cipher tests still pass

Closes #988
Closes #989