### PR TITLE
fix(deps): bump iOS OpenSSL-Universal to 3.6.2

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -69,7 +69,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - OpenSSL-Universal (3.6.0000)
+  - OpenSSL-Universal (3.6.2000)
   - QuickCrypto (1.1.4):
     - boost
     - DoubleConversion
@@ -78,7 +78,7 @@ PODS:
     - glog
     - hermes-engine
     - NitroModules
-    - OpenSSL-Universal (~> 3.6)
+    - OpenSSL-Universal (~> 3.6.2000)
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTRequired
@@ -2840,8 +2840,8 @@ SPEC CHECKSUMS:
   MMKVCore: f2dd4c9befea04277a55e84e7812f930537993df
   NitroMmkv: afbc5b2fbf963be567c6c545aa1efcf6a9cec68e
   NitroModules: 11bba9d065af151eae51e38a6425e04c3b223ff3
-  OpenSSL-Universal: 9110d21982bb7e8b22a962b6db56a8aa805afde7
-  QuickCrypto: 0bf36e49ac4e8040bdfa3b730da8f5e6ec677367
+  OpenSSL-Universal: ecee7b138fa75a74ecf00d7ffd248fb584739b9e
+  QuickCrypto: c9fb3cf63b789c33d283424c4ec7b01c4551b71b
   RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
   RCTDeprecation: c4b9e2fd0ab200e3af72b013ed6113187c607077
   RCTRequired: e97dd5dafc1db8094e63bc5031e0371f092ae92a

--- a/packages/react-native-quick-crypto/QuickCrypto.podspec
+++ b/packages/react-native-quick-crypto/QuickCrypto.podspec
@@ -184,7 +184,7 @@ Pod::Spec.new do |s|
   load "nitrogen/generated/ios/QuickCrypto+autolinking.rb"
   add_nitrogen_files(s)
 
-  s.dependency "OpenSSL-Universal", "~> 3.6"
+  s.dependency "OpenSSL-Universal", "~> 3.6.2000"
   s.dependency "React-jsi"
   s.dependency "React-callinvoker"
 


### PR DESCRIPTION
## Summary

Bump the iOS `OpenSSL-Universal` CocoaPod to `3.6.2000` (OpenSSL 3.6.2) to clear four CVEs published against OpenSSL 3.6.1.

## Changes

- `QuickCrypto.podspec`: pin `OpenSSL-Universal` to `~> 3.6.2000`
- `example/ios/Podfile.lock`: refresh to pull pod `3.6.2000`

## CVEs cleared

| CVE | Severity | Component | RNQC reachable? |
| --- | --- | --- | --- |
| CVE-2025-15467 | High | CMS EnvelopedData stack overflow | No |
| CVE-2026-2673 | Low | TLS1.3 group selection | No |
| CVE-2025-11187 | Moderate | PBMAC1 / PKCS#12 | No |
| CVE-2026-31790 | Moderate | RSA-KEM RSASVE | No |

None are reachable from RNQC's current API surface, but the bump clears scanners and removes latent risk.

## Testing

- iOS E2E workflow on CI
- `pod install` in `example/ios` resolves cleanly to `3.6.2000`

Closes #987